### PR TITLE
fix(install): rebuild wakatime-mcp venv with Python >=3.10

### DIFF
--- a/QUICKREF.md
+++ b/QUICKREF.md
@@ -309,7 +309,11 @@ cd ~/Public/dot-configs && git pull
   `MOSconfig/recursive-code-config` releases into `~/Library/Fonts`.
 - WakaTime MCP prompts in red for `~/.wakatime.cfg` `api_key` if missing,
   requiring the user to enter the key twice with hidden input before writing
-  the local config and MCP entry.
+  the local config and MCP entry. Its venv (`~/.local/share/wakatime-mcp/venv`)
+  needs Python >=3.10 (`requirements.txt` pins `mcp>=1.26`); install.sh resolves
+  a new-enough interpreter via `find_python` (probing `python3.1x` before bare
+  `python3`, since macOS's Xcode `python3` is 3.9.x) and rebuilds the venv if a
+  prior run created it with Python <3.10.
 - Copilot WakaTime upload is handled separately by
   `@geeknees/copilot-cli-wakatime` + `.github/hooks/wakatime.json`, and is
   initialized only after Copilot CLI, `wakatime-cli`, the npm hook package, and

--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,27 @@ have_cmd() {
   command -v "$1" >/dev/null 2>&1
 }
 
+# Resolve a python interpreter satisfying a minimum version (default >=3.10).
+# Prints the resolved command path on stdout; returns non-zero if none found.
+# macOS's Xcode python3 is 3.9.x, so we probe explicit minor versions first
+# (Homebrew installs python3.1x) before falling back to bare python3/python.
+find_python() {
+  local min_major="${1:-3}"
+  local min_minor="${2:-10}"
+  local candidate
+  for candidate in \
+    python3.14 python3.13 python3.12 python3.11 python3.10 python3 python; do
+    have_cmd "$candidate" || continue
+    if "$candidate" -c \
+      "import sys; sys.exit(0 if sys.version_info[:2] >= ($min_major, $min_minor) else 1)" \
+      >/dev/null 2>&1; then
+      command -v "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
 log_command() {
   local arg
   printf '+'
@@ -821,21 +842,39 @@ if [ -d "$claude_src" ]; then
     if [ -z "$wm_key" ]; then
       echo "wakatime-mcp: no API key available — skipping registration"
     else
-        mkdir -p "$wm_dest"
-        cp "$wm_src/server.py" "$wm_src/wakatime_client.py" "$wm_dest/"
-        if [ ! -d "$wm_dest/venv" ]; then
-          echo "wakatime-mcp: bootstrapping venv at $wm_dest/venv (one-time, ~30s)"
-          python3 -m venv "$wm_dest/venv" \
-            && "$wm_dest/venv/bin/pip" install --upgrade pip \
-            && "$wm_dest/venv/bin/pip" install -r "$wm_src/requirements.txt" \
-            && echo "wakatime-mcp: venv ready" \
-            || echo "Warning: wakatime-mcp venv bootstrap failed"
+        # requirements.txt pins mcp>=1.26, which needs Python >=3.10.
+        # macOS's Xcode python3 is 3.9.x, so resolve a new-enough interpreter
+        # (Homebrew python3.1x) rather than whatever bare python3 points at.
+        wm_py="$(find_python 3 10 || true)"
+        if [ -z "$wm_py" ]; then
+          echo "Warning: wakatime-mcp needs Python >=3.10 but none was found — skipping"
         else
-          # Refresh deps quietly only if requirements.txt is newer than
-          # the venv's marker. Cheap mtime check; pip itself is idempotent.
-          if [ "$wm_src/requirements.txt" -nt "$wm_dest/venv/pyvenv.cfg" ]; then
-            "$wm_dest/venv/bin/pip" install -r "$wm_src/requirements.txt" \
-              && touch "$wm_dest/venv/pyvenv.cfg"
+          mkdir -p "$wm_dest"
+          cp "$wm_src/server.py" "$wm_src/wakatime_client.py" "$wm_dest/"
+          # Discard a venv built with too-old a Python (e.g. a prior run that
+          # used Xcode's 3.9.6); it can't satisfy requirements.txt and pip
+          # would fail. Rebuilding is cheap and idempotent.
+          if [ -d "$wm_dest/venv" ] \
+            && ! "$wm_dest/venv/bin/python3" -c \
+                 "import sys; sys.exit(0 if sys.version_info[:2] >= (3, 10) else 1)" \
+                 >/dev/null 2>&1; then
+            echo "wakatime-mcp: existing venv has Python <3.10 — rebuilding"
+            rm -rf "$wm_dest/venv"
+          fi
+          if [ ! -d "$wm_dest/venv" ]; then
+            echo "wakatime-mcp: bootstrapping venv at $wm_dest/venv (one-time, ~30s)"
+            "$wm_py" -m venv "$wm_dest/venv" \
+              && "$wm_dest/venv/bin/pip" install --upgrade pip \
+              && "$wm_dest/venv/bin/pip" install -r "$wm_src/requirements.txt" \
+              && echo "wakatime-mcp: venv ready" \
+              || echo "Warning: wakatime-mcp venv bootstrap failed"
+          else
+            # Refresh deps quietly only if requirements.txt is newer than
+            # the venv's marker. Cheap mtime check; pip itself is idempotent.
+            if [ "$wm_src/requirements.txt" -nt "$wm_dest/venv/pyvenv.cfg" ]; then
+              "$wm_dest/venv/bin/pip" install -r "$wm_src/requirements.txt" \
+                && touch "$wm_dest/venv/pyvenv.cfg"
+            fi
           fi
         fi
         # Register the MCP entry into the user's per-machine mcp.json so

--- a/install.sh
+++ b/install.sh
@@ -837,44 +837,43 @@ if [ -d "$claude_src" ]; then
   wm_src="${src_dir}/wakatime-mcp"
   wm_dest="${HOME}/.local/share/wakatime-mcp"
   wm_cfg="${HOME}/.wakatime.cfg"
-  if [ -d "$wm_src" ] && have_cmd python3; then
-    wm_key="$(ensure_wakatime_cfg_api_key "$wm_cfg" || true)"
-    if [ -z "$wm_key" ]; then
-      echo "wakatime-mcp: no API key available — skipping registration"
+  if [ -d "$wm_src" ]; then
+    # requirements.txt pins mcp>=1.26, which needs Python >=3.10.
+    # macOS's Xcode python3 is 3.9.x, so resolve a new-enough interpreter
+    # (Homebrew python3.1x) rather than whatever bare python3 points at.
+    wm_py="$(find_python 3 10 || true)"
+    if [ -z "$wm_py" ]; then
+      echo "Warning: wakatime-mcp needs Python >=3.10 but none was found — skipping"
     else
-        # requirements.txt pins mcp>=1.26, which needs Python >=3.10.
-        # macOS's Xcode python3 is 3.9.x, so resolve a new-enough interpreter
-        # (Homebrew python3.1x) rather than whatever bare python3 points at.
-        wm_py="$(find_python 3 10 || true)"
-        if [ -z "$wm_py" ]; then
-          echo "Warning: wakatime-mcp needs Python >=3.10 but none was found — skipping"
+      wm_key="$(ensure_wakatime_cfg_api_key "$wm_cfg" || true)"
+      if [ -z "$wm_key" ]; then
+        echo "wakatime-mcp: no API key available — skipping registration"
+      else
+        mkdir -p "$wm_dest"
+        cp "$wm_src/server.py" "$wm_src/wakatime_client.py" "$wm_dest/"
+        # Discard a venv built with too-old a Python (e.g. a prior run that
+        # used Xcode's 3.9.6); it can't satisfy requirements.txt and pip
+        # would fail. Rebuilding is cheap and idempotent.
+        if [ -d "$wm_dest/venv" ] \
+          && ! "$wm_dest/venv/bin/python3" -c \
+               "import sys; sys.exit(0 if sys.version_info[:2] >= (3, 10) else 1)" \
+               >/dev/null 2>&1; then
+          echo "wakatime-mcp: existing venv has Python <3.10 — rebuilding"
+          rm -rf "$wm_dest/venv"
+        fi
+        if [ ! -d "$wm_dest/venv" ]; then
+          echo "wakatime-mcp: bootstrapping venv at $wm_dest/venv (one-time, ~30s)"
+          "$wm_py" -m venv "$wm_dest/venv" \
+            && "$wm_dest/venv/bin/pip" install --upgrade pip \
+            && "$wm_dest/venv/bin/pip" install -r "$wm_src/requirements.txt" \
+            && echo "wakatime-mcp: venv ready" \
+            || echo "Warning: wakatime-mcp venv bootstrap failed"
         else
-          mkdir -p "$wm_dest"
-          cp "$wm_src/server.py" "$wm_src/wakatime_client.py" "$wm_dest/"
-          # Discard a venv built with too-old a Python (e.g. a prior run that
-          # used Xcode's 3.9.6); it can't satisfy requirements.txt and pip
-          # would fail. Rebuilding is cheap and idempotent.
-          if [ -d "$wm_dest/venv" ] \
-            && ! "$wm_dest/venv/bin/python3" -c \
-                 "import sys; sys.exit(0 if sys.version_info[:2] >= (3, 10) else 1)" \
-                 >/dev/null 2>&1; then
-            echo "wakatime-mcp: existing venv has Python <3.10 — rebuilding"
-            rm -rf "$wm_dest/venv"
-          fi
-          if [ ! -d "$wm_dest/venv" ]; then
-            echo "wakatime-mcp: bootstrapping venv at $wm_dest/venv (one-time, ~30s)"
-            "$wm_py" -m venv "$wm_dest/venv" \
-              && "$wm_dest/venv/bin/pip" install --upgrade pip \
-              && "$wm_dest/venv/bin/pip" install -r "$wm_src/requirements.txt" \
-              && echo "wakatime-mcp: venv ready" \
-              || echo "Warning: wakatime-mcp venv bootstrap failed"
-          else
-            # Refresh deps quietly only if requirements.txt is newer than
-            # the venv's marker. Cheap mtime check; pip itself is idempotent.
-            if [ "$wm_src/requirements.txt" -nt "$wm_dest/venv/pyvenv.cfg" ]; then
-              "$wm_dest/venv/bin/pip" install -r "$wm_src/requirements.txt" \
-                && touch "$wm_dest/venv/pyvenv.cfg"
-            fi
+          # Refresh deps quietly only if requirements.txt is newer than
+          # the venv's marker. Cheap mtime check; pip itself is idempotent.
+          if [ "$wm_src/requirements.txt" -nt "$wm_dest/venv/pyvenv.cfg" ]; then
+            "$wm_dest/venv/bin/pip" install -r "$wm_src/requirements.txt" \
+              && touch "$wm_dest/venv/pyvenv.cfg"
           fi
         fi
         # Register the MCP entry into the user's per-machine mcp.json so
@@ -897,6 +896,7 @@ if [ -d "$claude_src" ]; then
             && echo "wakatime-mcp: registered in $copilot_mcp_pre" \
             || { rm -f "$tmp_mcp"; echo "Warning: wakatime-mcp jq registration failed"; }
         fi
+      fi
     fi
   fi
 


### PR DESCRIPTION
## Summary

`install.sh` ran to completion (exit 0) but emitted a hard error in the wakatime-mcp step on re-run:

```
ERROR: Could not find a version that satisfies the requirement mcp>=1.26
ERROR: No matching distribution found for mcp>=1.26
```

**Root cause:** the wakatime-mcp venv at `~/.local/share/wakatime-mcp/venv` had been bootstrapped with whatever `python3` resolved to — on macOS that's Xcode's **Python 3.9.6**. `wakatime-mcp/requirements.txt` pins `mcp>=1.26`, which requires **Python >=3.10**, so the `pip install` failed while reusing the stale 3.9.x venv — even though Homebrew Python 3.14 was available on PATH.

## Changes

- Add a `find_python` helper that probes `python3.14 … python3.10` before bare `python3`/`python` and returns the first interpreter meeting a minimum version (default `>=3.10`).
- Use the resolved interpreter for venv creation, and **rebuild** any existing venv whose Python is `<3.10` (cheap + idempotent).
- Skip gracefully with a warning if no `>=3.10` interpreter exists.
- Document the requirement + rebuild behavior in `QUICKREF.md`.

## Test plan

- [x] `bash -n install.sh` — syntax OK
- [x] Re-ran `install.sh`: stale 3.9.6 venv detected and rebuilt with Python 3.14.5; `mcp` / `fastmcp` / `httpx` installed — no ERROR
- [x] Confirmed deps import: `python3 -c "import mcp, fastmcp, httpx"`
- [x] Idempotent: second re-run skips rebuild, goes straight to MCP registration
- [x] CLAUDE.md smoke tests pass (`install.sh` syntax + both statuslines)

> Note for maintainer: per the release convention this is a patch-level bugfix — suggest tagging `v1.0.1` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)