### PR TITLE
fix(launchd): detect a relay that is up but cannot reach Copilot

### DIFF
--- a/QUICKREF.md
+++ b/QUICKREF.md
@@ -39,11 +39,20 @@ creates symlinks into `$HOME` (and `~/.oh-my-zsh/custom/`).
   into `~/.copilot-relay/config.yaml`, unloads/removes legacy proxy launchd
   jobs, and restarts the relay agent so it runs the latest installed version.
 - `launchd/com.d0n9x1n.copilot-relay-healthcheck.plist` +
-  `launchd/copilot-relay-healthcheck.sh` — macOS launchd watchdog. Runs at load
-  and every 60s, calls `GET http://127.0.0.1:4142/healthz`, and
-  `launchctl kickstart -k`s `com.d0n9x1n.copilot-relay` if the status is not
-  200. Healthy status is a no-op. Logs restart events to
-  `~/Library/Logs/copilot-relay-healthcheck.log`.
+  `launchd/copilot-relay-healthcheck.sh` — macOS launchd watchdog, **two tiers**.
+  Runs at load and every 60s. **Tier 1 (every run, free):** `GET
+  http://127.0.0.1:4142/healthz`; not-200 means the process is gone, so
+  `launchctl kickstart -k` the relay. `/healthz` is a static handler that never
+  contacts Copilot, so 200 proves only that a socket is listening. **Tier 2
+  (time-gated, every 900s):** `copilot-relay status --deep` sends a real request
+  through Copilot — the only check that catches a relay that is listening but
+  whose token expired. Exit `1` (not running) and `2` (listening, cannot reach
+  Copilot — usually expired auth, where the fix is `copilot-relay auth`, not a
+  restart) are logged distinctly. Needs `copilot-relay >= 0.2.6`. Healthy is a
+  no-op at both tiers. Tune with `COPILOT_RELAY_DEEP_INTERVAL` (0 disables) and
+  `COPILOT_RELAY_DEEP_MAX_TIME`. Logs to
+  `~/Library/Logs/copilot-relay-healthcheck.log`; deep-check timestamp in
+  `~/Library/Caches/copilot-relay-healthcheck.deep`.
 - `launchd/com.d0n9x1n.npm-cache-clean.plist` + `launchd/clean-npm-caches.sh`
   — macOS launchd agent **template** + its tracked script. install.sh renders
   `__HOME__` -> `$HOME` and `__SRC_DIR__` -> repo path into

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -45,8 +45,8 @@ dot-configs/
 ├── themes/apollo/               # Apollo theme (wezterm/vim/nvim/vscode/wt) — reference, not auto-linked
 ├── launchd/                     # macOS launchd agent templates
 │   ├── com.d0n9x1n.copilot-relay.plist     # copilot-relay proxy on login (rendered by install.sh)
-│   ├── com.d0n9x1n.copilot-relay-healthcheck.plist  # /healthz watchdog
-│   ├── copilot-relay-healthcheck.sh        # restarts relay when /healthz is not 200
+│   ├── com.d0n9x1n.copilot-relay-healthcheck.plist  # relay watchdog (liveness + deep)
+│   ├── copilot-relay-healthcheck.sh        # /healthz every 60s; status --deep every 900s
 │   ├── com.d0n9x1n.npm-cache-clean.plist   # weekly npm/npx cache cleaner (rendered by install.sh)
 │   └── clean-npm-caches.sh                 # the cleaner script the agent runs
 ├── mcp-shared.json              # secret-free MCP entries synced via git
@@ -119,14 +119,20 @@ probes do not appear as errors.
    if missing, then runs `tpm/bin/install_plugins` to clone every plugin
    listed in `.tmux.conf`. Skipped if `tmux` isn't on PATH.
 12. Links `.copilot-relay/config.yaml` to `~/.copilot-relay/config.yaml`, removes
-   legacy proxy launchd jobs, and writes the per-user launchd agent plus a
-   `/healthz` watchdog. The watchdog runs at load and every 60 seconds; if
-   `GET http://127.0.0.1:4142/healthz` does not return 200, it restarts
-   `com.d0n9x1n.copilot-relay` with `launchctl kickstart -k`; healthy status is
-   a no-op. The installer uses the same rule: if `/healthz` is already 200, it
-   leaves the running relay untouched. If relay is not authenticated, the
-   installer prints a red `ACTION REQUIRED` message to run `npx copilot-relay auth`
-   first; after auth, re-run `install.sh` to start it.
+   legacy proxy launchd jobs, and writes the per-user launchd agent plus its
+   watchdog. The watchdog runs at load and every 60 seconds, in two tiers.
+   **Liveness (every run, free):** if `GET http://127.0.0.1:4142/healthz` does
+   not return 200 the relay process is gone, so it restarts
+   `com.d0n9x1n.copilot-relay` with `launchctl kickstart -k`. **Deep (every 900
+   seconds):** `copilot-relay status --deep` sends a real request through
+   Copilot, catching a relay that is listening but cannot reach Copilot — the
+   case `/healthz` cannot see, since it never contacts Copilot. `not running`
+   and `listening but unusable` are logged distinctly; the latter is usually
+   expired auth, where the fix is `copilot-relay auth` rather than a restart.
+   Healthy is a no-op at both tiers. The installer uses the liveness rule: if
+   `/healthz` is already 200, it leaves the running relay untouched. If relay is
+   not authenticated, the installer prints a red `ACTION REQUIRED` message to run
+   `npx copilot-relay auth` first; after auth, re-run `install.sh` to start it.
 13. Writes the `npm-cache-clean` launchd agent (macOS): a weekly job (Sun 03:17)
    that runs `npm cache clean --force` and prunes `~/.npm/_npx` copies older than
    14 days, keeping the cache from growing unbounded. Needs no auth; never touches
@@ -231,17 +237,26 @@ test -f ~/.copilot-relay/github_token && echo "ok" || echo "FAIL: auth incomplet
 After `npx copilot-relay auth`, re-run `install.sh`; the launchd agent should
 start serving the proxy. The agent (`com.d0n9x1n.copilot-relay`) starts on every
 login and restarts on crash. A sibling watchdog
-(`com.d0n9x1n.copilot-relay-healthcheck`) calls `GET /healthz` at load and every
-60 seconds; 200 is a no-op, and a non-200 response triggers
-`launchctl kickstart -k` for the relay.
+(`com.d0n9x1n.copilot-relay-healthcheck`) runs at load and every 60 seconds, in
+two tiers: it calls `GET /healthz` on every run (200 is a no-op; anything else
+means the process is gone, so it `launchctl kickstart -k`s the relay), and every
+900 seconds it also runs `copilot-relay status --deep`, which sends a real
+request through Copilot. The deep tier is what catches a relay that is listening
+but whose Copilot token expired — `/healthz` returns 200 in that state because it
+never contacts Copilot.
 Relay logs go to `~/Library/Logs/copilot-relay.{out,err}.log` plus
-`~/.copilot-relay/logs/copilot-relay.log`; watchdog restart logs go to
-`~/Library/Logs/copilot-relay-healthcheck.log`. Verify:
+`~/.copilot-relay/logs/copilot-relay.log`; watchdog restart logs (both tiers) go
+to `~/Library/Logs/copilot-relay-healthcheck.log`, and the deep-check timestamp
+lives at `~/Library/Caches/copilot-relay-healthcheck.deep`. Verify:
 
 ```bash
 launchctl print "gui/$(id -u)/com.d0n9x1n.copilot-relay" | grep state
 launchctl print "gui/$(id -u)/com.d0n9x1n.copilot-relay-healthcheck" | grep state
 curl -sS -o /dev/null --connect-timeout 1 http://127.0.0.1:4142/healthz && echo "healthy"
+
+# Run the deep tier on demand (spends a few tokens).
+# Exit 0 = reachable, 1 = not running, 2 = listening but cannot reach Copilot.
+copilot-relay status --deep; echo "exit=$?"
 ```
 
 If the agent is loaded but port 4142 is not listening after auth, restart it:

--- a/launchd/com.d0n9x1n.copilot-relay-healthcheck.plist
+++ b/launchd/com.d0n9x1n.copilot-relay-healthcheck.plist
@@ -12,14 +12,24 @@
 
   What the agent does once loaded:
     - Runs launchd/copilot-relay-healthcheck.sh at load and every 60 seconds.
-    - The script calls GET http://127.0.0.1:4142/healthz.
-    - HTTP 200 means healthy; anything else triggers
-      launchctl kickstart -k gui/<uid>/com.d0n9x1n.copilot-relay.
+    - Tier 1, every run: GET http://127.0.0.1:4142/healthz. Anything but 200
+      triggers launchctl kickstart -k gui/<uid>/com.d0n9x1n.copilot-relay.
+      /healthz is a static handler in copilot-relay that never contacts
+      Copilot, so 200 proves only that a socket is listening.
+    - Tier 2, time-gated to every 900s: copilot-relay status --deep, which
+      sends a real request through Copilot. This is the tier that catches a
+      relay that is up but whose Copilot token expired. Exit 1 (not running)
+      and exit 2 (listening but unusable — usually expired auth, fixed by
+      `copilot-relay auth` rather than a restart) are logged distinctly.
+      Requires copilot-relay >= 0.2.6.
+    - Tune via COPILOT_RELAY_DEEP_INTERVAL (0 disables the deep tier) and
+      COPILOT_RELAY_DEEP_MAX_TIME.
 
   Logs:
     stdout -> ~/Library/Logs/copilot-relay-healthcheck.out.log
     stderr -> ~/Library/Logs/copilot-relay-healthcheck.err.log
     script log -> ~/Library/Logs/copilot-relay-healthcheck.log (capped)
+    deep-check timestamp -> ~/Library/Caches/copilot-relay-healthcheck.deep
 -->
 <plist version="1.0">
 <dict>

--- a/launchd/copilot-relay-healthcheck.sh
+++ b/launchd/copilot-relay-healthcheck.sh
@@ -1,8 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# launchd watchdog for copilot-relay. It checks the local health endpoint and
-# only restarts the relay agent when the HTTP service does not respond healthy.
+# launchd watchdog for copilot-relay. Two tiers, because the cheap check and
+# the meaningful check have very different costs:
+#
+#   1. Liveness — every run (StartInterval, 60s). GET /healthz. Free and fast,
+#      but /healthz is a static handler in copilot-relay that never contacts
+#      GitHub Copilot, so 200 proves only that a socket is listening. A relay
+#      whose Copilot token expired an hour ago still answers 200.
+#
+#   2. Deep — time-gated (default every 900s). `copilot-relay status --deep`
+#      sends a real request through Copilot, exercising token refresh, the
+#      upstream round trip, and translation. This is the only check that
+#      catches a relay that is listening but cannot reach Copilot. It spends
+#      a few tokens per run, hence the long interval.
+#
+# `status --deep` exit codes (requires copilot-relay >= 0.2.6, which
+# install.sh keeps current):
+#   0  running and reachable
+#   1  not running
+#   2  running but not usable (health probe or upstream round trip failed)
+#
+# 1 and 2 are logged distinctly: a restart fixes 1, but 2 is usually expired
+# auth, where the real fix is `copilot-relay auth` and a restart just loops.
+#
+# Tuning (all optional env vars):
+#   COPILOT_RELAY_DEEP_INTERVAL   seconds between deep checks; 0 disables
+#   COPILOT_RELAY_DEEP_MAX_TIME   seconds before a hung deep check is killed
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
@@ -13,9 +37,13 @@ log_file="${COPILOT_RELAY_HEALTH_LOG:-${HOME}/Library/Logs/copilot-relay-healthc
 log_max_lines="${COPILOT_RELAY_HEALTH_LOG_MAX_LINES:-500}"
 connect_timeout="${COPILOT_RELAY_HEALTH_CONNECT_TIMEOUT:-1}"
 max_time="${COPILOT_RELAY_HEALTH_MAX_TIME:-3}"
+deep_interval="${COPILOT_RELAY_DEEP_INTERVAL:-900}"
+deep_max_time="${COPILOT_RELAY_DEEP_MAX_TIME:-45}"
+deep_stamp="${COPILOT_RELAY_DEEP_STAMP:-${HOME}/Library/Caches/copilot-relay-healthcheck.deep}"
 uid="$(id -u)"
 
 mkdir -p "$(dirname "$log_file")"
+mkdir -p "$(dirname "$deep_stamp")"
 
 ts() { date '+%Y-%m-%d %H:%M:%S'; }
 
@@ -30,11 +58,45 @@ cap_log() {
     || rm -f "${log_file}.tmp" 2>/dev/null || true
 }
 
-health_code() {
-  if ! command -v curl >/dev/null 2>&1; then
-    printf 'curl-missing'
-    return 0
+# Darwin stat first, GNU stat as fallback (repo convention).
+file_mtime() {
+  stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || printf '0'
+}
+
+# macOS has no coreutils `timeout`, and a hung deep check would block this
+# agent indefinitely — launchd will not start a second instance while the
+# first is still running, so one hang silently ends the watchdog. Bound it.
+# Returns 124 when the command had to be killed, mirroring coreutils.
+run_with_timeout() {
+  local secs="$1"
+  shift
+  local cmd_pid killer_pid rc
+
+  "$@" &
+  cmd_pid=$!
+
+  (
+    sleep "$secs"
+    kill -TERM "$cmd_pid" 2>/dev/null || true
+    sleep 2
+    kill -KILL "$cmd_pid" 2>/dev/null || true
+  ) >/dev/null 2>&1 &
+  killer_pid=$!
+
+  rc=0
+  wait "$cmd_pid" 2>/dev/null || rc=$?
+
+  kill -KILL "$killer_pid" 2>/dev/null || true
+  wait "$killer_pid" 2>/dev/null || true
+
+  # 143 SIGTERM / 137 SIGKILL: the killer fired.
+  if [ "$rc" -eq 143 ] || [ "$rc" -eq 137 ]; then
+    return 124
   fi
+  return "$rc"
+}
+
+health_code() {
   curl -sS -o /dev/null \
     --connect-timeout "$connect_timeout" \
     --max-time "$max_time" \
@@ -56,32 +118,98 @@ wait_for_health() {
   return 1
 }
 
+kickstart_relay() {
+  if launchctl print "gui/${uid}/${label}" >/dev/null 2>&1; then
+    launchctl kickstart -k "gui/${uid}/${label}" >/dev/null 2>&1 \
+      || log "failed to kickstart loaded ${label}"
+  elif [ -f "$plist" ]; then
+    launchctl bootstrap "gui/${uid}" "$plist" >/dev/null 2>&1 \
+      || log "failed to bootstrap ${label} from $plist"
+    launchctl kickstart -k "gui/${uid}/${label}" >/dev/null 2>&1 \
+      || log "failed to kickstart bootstrapped ${label}"
+  else
+    log "cannot start ${label}: plist missing at $plist"
+    return 1
+  fi
+  return 0
+}
+
+deep_due() {
+  local now last
+  [ "$deep_interval" -gt 0 ] || return 1
+  [ -f "$deep_stamp" ] || return 0
+  now="$(date +%s)"
+  last="$(file_mtime "$deep_stamp")"
+  [ $((now - last)) -ge "$deep_interval" ]
+}
+
+deep_status() {
+  local rc=0
+  run_with_timeout "$deep_max_time" copilot-relay status --deep >/dev/null 2>&1 || rc=$?
+  return "$rc"
+}
+
+# ---------------------------------------------------------------- tier 1
+# Liveness. Runs every invocation. A dead process is caught here, cheaply.
+
 code="$(health_code)"
-if [ "$code" = "200" ]; then
+if [ "$code" != "200" ]; then
+  log "copilot-relay unhealthy: GET $url -> ${code:-no_response}; restarting ${label}"
+  if kickstart_relay; then
+    if wait_for_health; then
+      log "copilot-relay recovered: GET $url -> 200"
+    else
+      log "copilot-relay still unhealthy after restart: GET $url -> $(health_code)"
+    fi
+  fi
   cap_log
   exit 0
 fi
 
-log "copilot-relay unhealthy: GET $url -> ${code:-no_response}; restarting ${label}"
+# ---------------------------------------------------------------- tier 2
+# Deep. Only reached when the socket is already answering 200, so this is
+# strictly about whether Copilot is reachable through the relay.
 
-if launchctl print "gui/${uid}/${label}" >/dev/null 2>&1; then
-  launchctl kickstart -k "gui/${uid}/${label}" >/dev/null 2>&1 \
-    || log "failed to kickstart loaded ${label}"
-elif [ -f "$plist" ]; then
-  launchctl bootstrap "gui/${uid}" "$plist" >/dev/null 2>&1 \
-    || log "failed to bootstrap ${label} from $plist"
-  launchctl kickstart -k "gui/${uid}/${label}" >/dev/null 2>&1 \
-    || log "failed to kickstart bootstrapped ${label}"
-else
-  log "cannot start ${label}: plist missing at $plist"
-  cap_log
-  exit 0
-fi
+deep_due || { cap_log; exit 0; }
 
-if wait_for_health; then
-  log "copilot-relay recovered: GET $url -> 200"
-else
-  log "copilot-relay still unhealthy after restart: GET $url -> $(health_code)"
+# Stamp before running, not after: a deep check that fails or hangs must not
+# retry every 60s and burn tokens.
+: >"$deep_stamp"
+
+deep_rc=0
+deep_status || deep_rc=$?
+
+case "$deep_rc" in
+  0)
+    cap_log
+    exit 0
+    ;;
+  1)
+    log "copilot-relay deep check: not running; restarting ${label}"
+    ;;
+  2)
+    log "copilot-relay deep check: listening but cannot reach Copilot (likely expired auth — run 'copilot-relay auth' if this repeats); restarting ${label}"
+    ;;
+  124)
+    log "copilot-relay deep check: timed out after ${deep_max_time}s; restarting ${label}"
+    ;;
+  *)
+    log "copilot-relay deep check: exit ${deep_rc}; restarting ${label}"
+    ;;
+esac
+
+if kickstart_relay; then
+  if wait_for_health; then
+    recheck_rc=0
+    deep_status || recheck_rc=$?
+    if [ "$recheck_rc" -eq 0 ]; then
+      log "copilot-relay recovered: deep check passed"
+    else
+      log "copilot-relay still cannot reach Copilot after restart (status --deep -> ${recheck_rc}); run 'copilot-relay auth'"
+    fi
+  else
+    log "copilot-relay still unhealthy after restart: GET $url -> $(health_code)"
+  fi
 fi
 
 cap_log


### PR DESCRIPTION
Closes #5.

## Problem

The watchdog decided health from `GET /healthz` alone. That endpoint is a static handler in copilot-relay — it never contacts Copilot — so a relay whose token expired an hour ago still answers `200`. The watchdog saw a healthy service while every Claude Code request failed.

A month of this machine's logs shows only `000` (could not connect at all). It has never once observed a non-200, because the only way `/healthz` returns non-200 is if the process is already gone. It was a liveness check wearing a health check's name.

## Change

Two tiers in one agent — no second plist, so the cheap check keeps its 60s cadence and the expensive one is gated by timestamp.

| Tier | Interval | Check | Catches |
| --- | --- | --- | --- |
| Liveness | 60s (unchanged) | `GET /healthz` | dead process |
| Deep | 900s | `copilot-relay status --deep` | expired auth, upstream failure |

Exit `1` (not running) and `2` (listening but unusable) log distinctly — a restart fixes `1`, but `2` is usually expired auth, where a restart just loops and the real fix is `copilot-relay auth`. After a deep-triggered restart the recheck is also deep, so recovery isn't declared on liveness alone.

The deep tier is bounded by a hand-rolled timeout (macOS has no coreutils `timeout`). launchd will not start a second instance while the first is still running, so one hung check would silently end the watchdog forever.

The stamp is written *before* the check, not after: a failing deep check must not retry every 60s and burn tokens.

## Verification

Exercised against a stubbed CLI returning each exit code, plus the real relay:

| Case | Result |
| --- | --- |
| healthy relay | no log, no restart, stamp written |
| time gate, immediate re-run | deep skipped, stamp unchanged |
| `COPILOT_RELAY_DEEP_INTERVAL=0` | deep disabled |
| exit `1` | `deep check: not running; restarting` |
| exit `2` | `listening but cannot reach Copilot (likely expired auth...)` |
| exit `124` (hang) | killed at 45s, logged as timeout |
| timeout wrapper fidelity | `1`→`1`, `2`→`2`, hang→`124` |

`scripts/check.sh all` passes; `shellcheck` clean; `bash -n` under macOS bash 3.2.

## Acceptance (from #5)

- [x] Watchdog can detect a relay listening but unable to reach Copilot
- [x] Cheap liveness check keeps its current interval
- [x] Deep check on a longer interval, token cost negligible
- [x] `not running` vs `running but unusable` logged distinctly
- [x] Documented in QUICKREF.md, ReadMe.md, and the plist header

Tuning: `COPILOT_RELAY_DEEP_INTERVAL` (0 disables), `COPILOT_RELAY_DEEP_MAX_TIME`. Requires `copilot-relay >= 0.2.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)