### PR TITLE
feat(claude): add global update-settings skill

### DIFF
--- a/QUICKREF.md
+++ b/QUICKREF.md
@@ -301,6 +301,9 @@ creates symlinks into `$HOME` (and `~/.oh-my-zsh/custom/`).
    **Creates the destination directory if missing** (Claude Code only creates
    `~/.claude/` on first launch), and removes the obsolete repo-managed
    `~/.claude/hooks/subagent-counter.sh` symlink while preserving user hooks.
+   Skills are one directory deeper (`claude/skills/<name>/SKILL.md`) and get a
+   separate pass linking each skill's files into `~/.claude/skills/<name>/`
+   — global, so they load in every project, not just this repo.
 8. Symlinks `wezterm/wezterm.lua` to `~/.wezterm.lua`.
 9. Symlinks tracked `.sonicterm` TOML files into `~/.sonicterm/` while leaving
    logs/backups local.
@@ -330,6 +333,9 @@ creates symlinks into `$HOME` (and `~/.oh-my-zsh/custom/`).
   Note: `mcp-config.json` is excluded (contains secrets) — manage it manually.
 - New Claude Code config: add a file to `claude/`, run `install.sh`.
   The destination directory is created automatically.
+- New Claude Code skill: add `claude/skills/<name>/SKILL.md` (frontmatter needs
+  `name` + a `description` with explicit TRIGGER/SKIP wording), run
+  `install.sh`. Supporting files in the same directory are linked too.
 - New SonicTerm config: add TOML under `.sonicterm/`, `.sonicterm/keymaps/`,
   or `.sonicterm/themes/`, run `install.sh`. Do not commit `~/.sonicterm/logs/`
   or runtime backup files.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -33,7 +33,9 @@ dot-configs/
 │   └── copilot-instructions.md  # global agent instructions
 ├── claude/                      # contents -> ~/.claude/
 │   ├── settings.json            # Claude Code settings
-│   └── statusline.sh            # statusline
+│   ├── statusline.sh            # statusline
+│   └── skills/                  # skills -> ~/.claude/skills/ (load in every project)
+│       └── update-settings/     # edit any config here correctly, then apply it
 ├── wezterm/                     # terminal config -> ~/.wezterm.lua
 │   └── wezterm.lua              # WezTerm config
 ├── .sonicterm/                  # tracked TOML config -> ~/.sonicterm/
@@ -100,7 +102,10 @@ probes do not appear as errors.
    `~/.claude/` on first launch; mkdir-p so install.sh wires things up on a
    fresh box). During migration it removes the obsolete
    `~/.claude/hooks/subagent-counter.sh` only when that path is still a symlink
-   to this repository; user-owned hooks are preserved.
+   to this repository; user-owned hooks are preserved. Skills live one directory
+   deeper (`claude/skills/<name>/SKILL.md`), so they get their own pass that
+   links each skill's files into `~/.claude/skills/<name>/` — global, meaning
+   they load in every project on the machine, not just this repo.
 8. Symlinks `wezterm/wezterm.lua` into `~/.wezterm.lua`.
 9. Symlinks tracked SonicTerm TOML files into `~/.sonicterm/`:
    `sonicterm.toml`, `keymaps/*.toml`, and `themes/*.toml`. Logs and runtime

--- a/claude/skills/update-settings/SKILL.md
+++ b/claude/skills/update-settings/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: update-settings
+description: Change any setting in the dot-configs repo correctly — edit the right file, mirror it to whatever it is coupled to, update QUICKREF.md + ReadMe.md, run scripts/check.sh, then apply it to this Mac via install.sh and reload the affected launchd agents. TRIGGER when the user asks to change, set, enable, disable, or tune configuration for any app this repo manages (Claude Code, Copilot CLI, WezTerm, tmux, SonicTerm, copilot-relay, launchd agents, zsh), or asks to re-apply/sync settings to the machine. SKIP for questions about what a setting currently is (just read the file), and for code changes that are not configuration.
+---
+
+# update-settings
+
+Settings in this repo are **coupled**. A one-file edit is usually wrong: the
+statusline has a sibling that must match, a model alias has a family rule, a
+launchd plist is a template that must be re-rendered, and every behavior change
+owes an update to QUICKREF.md. This skill makes the whole change.
+
+Two phases. Run **EDIT** then **APPLY** by default. Run APPLY alone when the
+user just wants the repo's current state pushed onto the machine ("re-sync",
+"re-run the installer", "my symlinks are stale").
+
+---
+
+## Phase 1 — EDIT
+
+### 1. Route to the right file
+
+Never edit `~/.claude/*`, `~/.wezterm.lua`, or anything else in `$HOME`
+directly — those are symlinks into this repo, and a direct edit either hits the
+repo through the link (untracked as a repo change) or gets clobbered on next
+install. Always edit the repo copy.
+
+| Setting | Edit here | Lands at | Coupled to |
+| --- | --- | --- | --- |
+| Claude Code behavior, env, model | `claude/settings.json` | `~/.claude/settings.json` | model family rule (below) |
+| Claude statusline | `claude/statusline.sh` | `~/.claude/statusline.sh` | **`copilot/statusline.sh`** |
+| Copilot CLI behavior | `copilot/settings.json` | `~/.config/github-copilot/` | — |
+| Copilot statusline | `copilot/statusline.sh` | — | **`claude/statusline.sh`** |
+| MCP server (no secret) | `mcp-shared.json` | merged into Copilot + `~/.claude.json` | — |
+| MCP server (needs token) | `~/.config/github-copilot/mcp.json` | per-device, gitignored | never commit |
+| Relay routing / effort | `.copilot-relay/config.yaml` | `~/.copilot-relay/config.yaml` | `claude/settings.json` model names |
+| Terminal | `wezterm/wezterm.lua` | `~/.wezterm.lua` | tmux truecolor, theme |
+| tmux | `.tmux.conf` | `~/.tmux.conf` | WezTerm truecolor |
+| SonicTerm | `.sonicterm/**.toml` | `~/.sonicterm/` | — |
+| Shell aliases / wrappers | `oh-my-zsh-custom/*.zsh` | `~/.oh-my-zsh/custom/` | permission-mode flags |
+| launchd agent | `launchd/*.plist` (**template**) | rendered to `~/Library/LaunchAgents/` | must re-render + reload |
+
+### 2. Apply the coupling rule that fits
+
+**Statusline parity.** `claude/statusline.sh` and `copilot/statusline.sh` must
+stay functionally aligned: same segments, same output shape, same Gruvbox
+palette, same per-cwd 5s git cache. Change one, port it to the other.
+
+One intentional divergence — **do not "re-align" it away**: Claude's statusline
+has no live-subagent rendering at all (no inline `subagents`/`Tasks` count, no
+bottom live-agent tree, no subagent glyph), because Claude Code ships native
+subagent UI and admission. Copilot keeps both, with the magic-wand glyph
+(U+F0D0).
+
+**Model routing.** Opus and Sonnet are separate families. Applying "the same
+model for the family" means within Opus **or** within Sonnet, never across.
+Current: anything containing `opus` → `claude-opus-5[1m]`; Sonnet/Haiku/small-fast
+→ `gpt-5.6-sol[1m]`. Keep the `[1m]` suffix — a bare custom name makes Claude
+Code fall back to 200k context accounting instead of 1M.
+
+**launchd.** Plists are templates, not symlinks. install.sh substitutes
+`__HOME__` → `$HOME` (launchd does not expand `$HOME` at runtime) and
+`__SRC_DIR__` → repo path, then `bootout`+`bootstrap` into `gui/<uid>`. Editing
+the rendered file in `~/Library/LaunchAgents/` is always wrong — it is
+overwritten on next install.
+
+**Statusline layout.** Five lines, `\n` tokens in `SEGMENTS` break lines:
+L1 time/run/api/cost · L2 model/effort/context · L3 mcp/skills/agents/style ·
+L4 cwd · L5 repo/branch/diff/stash/worktree. Icons are FontAwesome raw UTF-8
+bytes (bash 3.2 has no `\u`). Avoid repeating an accent color between adjacent
+segments or within a visual column.
+
+### 3. Known traps
+
+- `~/.claude/settings.json` and `~/.claude.json` are **different files**.
+  Settings = behavior. `.claude.json` top level = MCP servers + state.
+- `refreshInterval` nests **inside** `statusLine`, not at top level.
+- `permissions.defaultMode: "bypassPermissions"` is silently rejected by the
+  binary. The `--permission-mode bypassPermissions` CLI flag *is* honored —
+  that is why `oh-my-zsh-custom/claude.zsh` and `cc.zsh` wrap the launcher.
+- `skipDangerousModePermissionPrompt` is dead config; Claude Code re-adds it on
+  its own writes. Treat as noise, do not build on it.
+- Shell scripts: `set -euo pipefail`, **bash 3.2 compatible** (macOS default) —
+  no associative arrays, no `printf '%(...)T'`, no `\u`. Use
+  `stat -f %m || stat -c %Y` for mtime.
+
+### 4. Docs, then checks
+
+Behavior changed → **QUICKREF.md** (agent-facing, must stay accurate).
+User-visible → **ReadMe.md**. Both if both.
+
+```bash
+scripts/check.sh all
+```
+
+CI runs the same script. Do not proceed while it is red.
+
+---
+
+## Phase 2 — APPLY
+
+```bash
+./install.sh
+```
+
+Idempotent: relinks symlinks, re-renders every launchd template, and
+`bootout`+`bootstrap`s the agents. Correct links are left alone; mismatched
+destinations are backed up as `<name>.bak.YYYYMMDDHHMMSS` first.
+
+Reload a single agent without a full install:
+
+```bash
+launchctl kickstart -k "gui/$(id -u)/com.d0n9x1n.copilot-relay"
+```
+
+### Verify what you changed
+
+```bash
+# symlink landed where you think
+ls -l ~/.claude/settings.json ~/.wezterm.lua ~/.tmux.conf
+
+# agents loaded
+launchctl print "gui/$(id -u)/com.d0n9x1n.copilot-relay" | grep state
+launchctl print "gui/$(id -u)/com.d0n9x1n.copilot-relay-healthcheck" | grep state
+
+# relay reachable end to end (spends a few tokens)
+copilot-relay status --deep; echo "exit=$?"
+```
+
+Claude Code settings need a **session restart** to take effect. WezTerm and
+tmux reload their own config; SonicTerm and the relay hot-reload.
+
+---
+
+## Ship
+
+Semver-ish tags: patch = bugfix, minor = new feature, major = breaking.
+Pushing `v*.*.*` triggers `.github/workflows/release.yml`, whose release body
+is the commit subjects since the previous reachable tag.
+
+```bash
+git tag -a vX.Y.Z -m "..." && git push origin vX.Y.Z
+```
+
+If the change closes an issue, attach issue and PR to a milestone named for the
+tag. Never `--no-verify` a commit unless the user explicitly asks.
+
+## Never
+
+- Commit a token, key, or `github_token` — the repo is **public**.
+- Add a path outside `claude/`, `copilot/`, `oh-my-zsh-custom/`, `wezterm/`
+  without an install.sh update to link it.
+- Commit SonicTerm `logs/`, relay logs, or `copilot_token.json`.
+- Add a non-macOS branch. This repo is macOS-only and untested elsewhere.

--- a/install.sh
+++ b/install.sh
@@ -984,6 +984,24 @@ if [ -d "$claude_src" ]; then
   done < <(find "$claude_src" -maxdepth 1 -mindepth 1 -type f -print0)
   echo "Linked Claude Code config files to $claude_dest"
 
+  # Skills live one directory deep (claude/skills/<name>/SKILL.md), so the
+  # -type f loop above does not see them. Link each skill directory's files
+  # individually — same approach as the SonicTerm subdirectory pass — so a
+  # skill can ship supporting files alongside SKILL.md later.
+  claude_skills_src="${claude_src}/skills"
+  if [ -d "$claude_skills_src" ]; then
+    mkdir -p "${claude_dest}/skills"
+    while IFS= read -r -d '' skill_dir; do
+      skill_name="$(basename "$skill_dir")"
+      mkdir -p "${claude_dest}/skills/${skill_name}"
+      while IFS= read -r -d '' entry; do
+        base="$(basename "$entry")"
+        link_file "$entry" "${claude_dest}/skills/${skill_name}/${base}"
+      done < <(find "$skill_dir" -maxdepth 1 -mindepth 1 -type f -print0)
+    done < <(find "$claude_skills_src" -maxdepth 1 -mindepth 1 -type d -print0)
+    echo "Linked Claude Code skills to ${claude_dest}/skills"
+  fi
+
   # Claude Code v2.1.217 added a native concurrent-subagent limit. Remove only
   # the obsolete repo-managed hook symlink; preserve user-owned hooks/files.
   remove_legacy_claude_subagent_hook


### PR DESCRIPTION
## Why

Settings here are **coupled**, so a one-file edit is usually an incomplete change:

- `claude/statusline.sh` has a sibling (`copilot/statusline.sh`) that must stay functionally aligned — with one intentional divergence that must *not* be re-aligned away
- model aliases follow a per-family rule (Opus and Sonnet never cross)
- launchd plists are templates; editing the rendered file in `~/Library/LaunchAgents/` is always wrong
- any behavior change owes an update to QUICKREF.md

Today that knowledge lives in CLAUDE.md and depends on remembering it at the right moment.

## What

A skill with two phases:

**EDIT** — routes the change to the right file via a surface table (which file, where it lands, what it's coupled to), applies the matching coupling rule, lists the traps that have actually bitten this repo (`settings.json` vs `.claude.json`, `refreshInterval` nesting inside `statusLine`, `bypassPermissions` silently rejected in settings but honored as a CLI flag), then updates docs and runs `scripts/check.sh all`.

**APPLY** — runs `install.sh`, reloads the launchd agents, verifies symlinks and agent state, and notes what needs a session restart vs. what hot-reloads.

## Installer change

Skills live one directory deeper than the existing `claude/` loop can see (`-maxdepth 1 -type f`), so `claude/skills/` was silently invisible to it. Adds a pass linking each skill directory's files into `~/.claude/skills/<name>/`.

Global rather than repo-scoped, per request — it loads in every project. It links *every* file in the skill directory, not just `SKILL.md`, so a skill can ship supporting references later.

## Verification

| Check | Result |
| --- | --- |
| `install.sh` (brew/npm/omz skipped) | `Linked Claude Code skills to ~/.claude/skills` |
| symlink resolution | resolves back into the repo |
| content through link | reads correctly |
| idempotency (2 runs) | links unchanged |
| multi-file skill | supporting files linked too |
| coexistence | user-owned `fc-*` skills untouched |

`scripts/check.sh all` passes. `shellcheck install.sh` surfaces only pre-existing `info` findings on untouched lines (CI gates on `error`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)