### PR TITLE
Default AI clients to GPT-6 Astra and compact at 75k

### DIFF
--- a/config/claude/CLAUDE.md
+++ b/config/claude/CLAUDE.md
@@ -1,5 +1,14 @@
 # Global Claude instructions
 
+## Response style
+
+- Lead with the answer. Use plain, direct language.
+- Keep conversational prose concise by default. Remove needless preamble, repetition, and filler.
+- Match detail to the user's requested depth.
+- Keep code, commands, diffs, findings, and requested deliverables complete.
+- Preserve necessary caveats, evidence, safety information, and technical precision.
+- Use headings or other structure when they improve clarity.
+
 ## Markdown diagrams
 
 Do not use ASCII-art flowcharts in Markdown. Use a fenced Mermaid diagram.

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -2,12 +2,12 @@
   "env": {
     "ANTHROPIC_BASE_URL": "http://127.0.0.1:4142",
     "ANTHROPIC_AUTH_TOKEN": "dummy",
-    "ANTHROPIC_MODEL": "claude-sonnet-5[1m]",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-5[1m]",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME": "Sonnet 5",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION": "Sonnet 5 (1M context), routed by copilot-relay to gpt-5.6-sol",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gpt-5.6-sol[1m]",
-    "ANTHROPIC_SMALL_FAST_MODEL": "gpt-5.6-sol[1m]",
+    "ANTHROPIC_MODEL": "gpt-6-astra[1m]",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "gpt-6-astra[1m]",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME": "GPT-6 Astra",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION": "GPT-6 Astra (1M context) through copilot-relay",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gpt-6-astra[1m]",
+    "ANTHROPIC_SMALL_FAST_MODEL": "gpt-6-astra[1m]",
     "MODEL_REASONING_EFFORT": "max",
     "CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS": "16"
   },
@@ -15,7 +15,7 @@
     "allow": [],
     "defaultMode": "auto"
   },
-  "model": "claude-sonnet-5[1m]",
+  "model": "gpt-6-astra[1m]",
   "effortLevel": "max",
   "statusLine": {
     "type": "command",

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -9,6 +9,7 @@
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gpt-6-astra[1m]",
     "ANTHROPIC_SMALL_FAST_MODEL": "gpt-6-astra[1m]",
     "MODEL_REASONING_EFFORT": "max",
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "75",
     "CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS": "16"
   },
   "permissions": {
@@ -16,7 +17,6 @@
     "defaultMode": "auto"
   },
   "model": "gpt-6-astra[1m]",
-  "effortLevel": "max",
   "statusLine": {
     "type": "command",
     "command": "~/.claude/statusline.sh",
@@ -26,7 +26,8 @@
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "claude-code-wakatime@wakatime": true,
-    "rust-analyzer-lsp@claude-plugins-official": true
+    "rust-analyzer-lsp@claude-plugins-official": true,
+    "clangd-lsp@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "wakatime": {
@@ -36,7 +37,10 @@
       }
     }
   },
+  "feedbackDrafts": "off",
+  "autoCompactWindow": 120000,
   "skipDangerousModePermissionPrompt": true,
+  "autoCompactEnabled": true,
   "skipAutoPermissionPrompt": true,
-  "autoCompactWindow": 800000
+  "theme": "custom:apollo"
 }

--- a/config/copilot-relay/config.yaml
+++ b/config/copilot-relay/config.yaml
@@ -37,7 +37,7 @@ webSearchBackend:
 # Model routing: requests containing "opus" use opusModel; all others use gptModel.
 
 # Upstream Copilot model used for non-Opus requests.
-gptModel: gpt-5.6-sol
+gptModel: gpt-6-astra
 
 # Upstream Copilot model used for requests containing "opus".
 opusModel: claude-opus-5

--- a/config/copilot/copilot-instructions.md
+++ b/config/copilot/copilot-instructions.md
@@ -1,5 +1,14 @@
 # Global Copilot CLI instructions
 
+## Response style
+
+- Lead with the answer. Use plain, direct language.
+- Keep conversational prose concise by default. Remove needless preamble, repetition, and filler.
+- Match detail to the user's requested depth.
+- Keep code, commands, diffs, findings, and requested deliverables complete.
+- Preserve necessary caveats, evidence, safety information, and technical precision.
+- Use headings or other structure when they improve clarity.
+
 - Run tools and commands without asking for approval.
 - Work on the task directly.
 - Read `AGENTS.md` for the global publishing pointer.

--- a/config/copilot/settings.json
+++ b/config/copilot/settings.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-opus-5",
+  "model": "gpt-6-astra",
   "contextTier": "long_context",
   "theme": "default",
   "renderMarkdown": true,

--- a/config/zsh/cc.zsh
+++ b/config/zsh/cc.zsh
@@ -34,6 +34,6 @@ function cc {
   if [[ -n "$RMUX" ]] && (( $+commands[rmux] )); then
     command rmux rename-window -- "$title" 2>/dev/null
   fi
-  command claude --permission-mode bypassPermissions --model 'claude-sonnet-5[1m]' --effort max
+  command claude --permission-mode bypassPermissions --model 'gpt-6-astra[1m]' --effort max
   unset DISABLE_AUTO_TITLE
 }

--- a/config/zsh/claude.zsh
+++ b/config/zsh/claude.zsh
@@ -28,7 +28,7 @@ function claude {
   done
 
   defaults=(--permission-mode bypassPermissions)
-  (( has_model )) || defaults+=(--model 'claude-sonnet-5[1m]')
+  (( has_model )) || defaults+=(--model 'gpt-6-astra[1m]')
   (( has_effort )) || defaults+=(--effort max)
 
   command claude "${defaults[@]}" "$@"

--- a/config/zsh/gg.zsh
+++ b/config/zsh/gg.zsh
@@ -29,6 +29,6 @@ function gg {
     command rmux rename-window -- "$title" 2>/dev/null
   fi
   TERM_PROGRAM=WezTerm COLORTERM=truecolor FORCE_COLOR=3 \
-    command copilot --allow-all-tools --allow-all-paths --model claude-opus-5 --context long_context --effort max
+    command copilot --allow-all-tools --allow-all-paths --model gpt-6-astra --context long_context --effort max
   unset DISABLE_AUTO_TITLE
 }

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -179,41 +179,41 @@ SH
 }
 
 run_model_default_smoke() {
-  # Claude Code: Sonnet 5 is the startup picker identity and the relay maps its
-  # non-Opus name to gpt-5.6-sol; "[1m]" keeps 1M-context accounting.
+  # Claude Code: GPT-6 Astra is the startup identity; "[1m]" keeps
+  # one-million-token client context accounting while relay strips it upstream.
   jq -e '
-    .env.ANTHROPIC_MODEL == "claude-sonnet-5[1m]" and
-    .model == "claude-sonnet-5[1m]" and
+    .env.ANTHROPIC_MODEL == "gpt-6-astra[1m]" and
+    .model == "gpt-6-astra[1m]" and
     .effortLevel == "max" and
     .env.MODEL_REASONING_EFFORT == "max" and
-    .env.ANTHROPIC_DEFAULT_SONNET_MODEL == "claude-sonnet-5[1m]" and
-    .env.ANTHROPIC_DEFAULT_SONNET_MODEL_NAME == "Sonnet 5" and
-    .env.ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION == "Sonnet 5 (1M context), routed by copilot-relay to gpt-5.6-sol" and
-    .env.ANTHROPIC_DEFAULT_HAIKU_MODEL == "gpt-5.6-sol[1m]" and
-    .env.ANTHROPIC_SMALL_FAST_MODEL == "gpt-5.6-sol[1m]"
+    .env.ANTHROPIC_DEFAULT_SONNET_MODEL == "gpt-6-astra[1m]" and
+    .env.ANTHROPIC_DEFAULT_SONNET_MODEL_NAME == "GPT-6 Astra" and
+    .env.ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION == "GPT-6 Astra (1M context) through copilot-relay" and
+    .env.ANTHROPIC_DEFAULT_HAIKU_MODEL == "gpt-6-astra[1m]" and
+    .env.ANTHROPIC_SMALL_FAST_MODEL == "gpt-6-astra[1m]"
   ' config/claude/settings.json >/dev/null
 
-  # Copilot CLI: Opus 5 at the 1M context tier and max effort.
+  # Copilot CLI: GPT-6 Astra at the 1M context tier and max effort.
   jq -e '
-    .model == "claude-opus-5" and
+    .model == "gpt-6-astra" and
     .contextTier == "long_context" and
     .effortLevel == "max"
   ' config/copilot/settings.json >/dev/null
 
-  # Relay: Opus route -> claude-opus-5, GPT route stays gpt-5.6-sol, max effort.
+  # Relay: Opus remains separate; every non-Opus route uses GPT-6 Astra.
   grep -Eq '^opusModel:[[:space:]]*claude-opus-5$' config/copilot-relay/config.yaml
-  grep -Eq '^gptModel:[[:space:]]*gpt-5\.6-sol$' config/copilot-relay/config.yaml
+  grep -Eq '^gptModel:[[:space:]]*gpt-6-astra$' config/copilot-relay/config.yaml
   grep -Eq '^thinkEffort:[[:space:]]*max$' config/copilot-relay/config.yaml
 
   grep -Fq $'link\tconfig/copilot-relay/config.yaml\t.copilot-relay/config.yaml' config/manifest.tsv
 
   # Launcher wrappers inject the same defaults (settings.json can be rewritten
   # at runtime, so the flags are the authoritative per-launch pin).
-  grep -Fq -- "--model 'claude-sonnet-5[1m]'" config/zsh/claude.zsh
-  grep -Fq -- "--model 'claude-sonnet-5[1m]' --effort max" config/zsh/cc.zsh
-  grep -Fq -- "--model claude-opus-5 --context long_context --effort max" config/zsh/gg.zsh
+  grep -Fq -- "--model 'gpt-6-astra[1m]'" config/zsh/claude.zsh
+  grep -Fq -- "--model 'gpt-6-astra[1m]' --effort max" config/zsh/cc.zsh
+  grep -Fq -- "--model gpt-6-astra --context long_context --effort max" config/zsh/gg.zsh
 
-  echo "model defaults ok: Sonnet 5 picker identity @ max effort, 1M context (relay upstream: gpt-5.6-sol)"
+  echo "model defaults ok: GPT-6 Astra @ max effort, 1M context"
 }
 
 run_copilot_terminal_smoke() {
@@ -240,7 +240,7 @@ SH
 
     PATH="$fake_bin:$PATH" COPILOT_CAPTURE="$gg_capture" TERM_PROGRAM=rmux \
       zsh -c 'unset RMUX TMUX WEZTERM_PANE; source config/zsh/gg.zsh; gg terminal-smoke >/dev/null; [[ "$TERM_PROGRAM" = rmux ]]'
-    grep -Fq 'WezTerm|truecolor|3|--allow-all-tools --allow-all-paths --model claude-opus-5 --context long_context --effort max' "$gg_capture"
+    grep -Fq 'WezTerm|truecolor|3|--allow-all-tools --allow-all-paths --model gpt-6-astra --context long_context --effort max' "$gg_capture"
   )
 
   echo "Copilot launchers advertise WezTerm truecolor without replacing RMUX identity"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -184,13 +184,18 @@ run_model_default_smoke() {
   jq -e '
     .env.ANTHROPIC_MODEL == "gpt-6-astra[1m]" and
     .model == "gpt-6-astra[1m]" and
-    .effortLevel == "max" and
+    (has("effortLevel") | not) and
     .env.MODEL_REASONING_EFFORT == "max" and
     .env.ANTHROPIC_DEFAULT_SONNET_MODEL == "gpt-6-astra[1m]" and
     .env.ANTHROPIC_DEFAULT_SONNET_MODEL_NAME == "GPT-6 Astra" and
     .env.ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION == "GPT-6 Astra (1M context) through copilot-relay" and
     .env.ANTHROPIC_DEFAULT_HAIKU_MODEL == "gpt-6-astra[1m]" and
-    .env.ANTHROPIC_SMALL_FAST_MODEL == "gpt-6-astra[1m]"
+    .env.ANTHROPIC_SMALL_FAST_MODEL == "gpt-6-astra[1m]" and
+    .autoCompactEnabled == true and
+    .autoCompactWindow == 120000 and
+    .env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE == "75" and
+    .feedbackDrafts == "off" and
+    .enabledPlugins["clangd-lsp@claude-plugins-official"] == true
   ' config/claude/settings.json >/dev/null
 
   # Copilot CLI: GPT-6 Astra at the 1M context tier and max effort.
@@ -276,6 +281,9 @@ run_global_instructions_smoke() {
   done
 
   grep -Fq 'Do not use ASCII-art flowcharts' config/claude/CLAUDE.md
+  for file in config/claude/CLAUDE.md config/copilot/copilot-instructions.md; do
+    grep -Fq 'Keep conversational prose concise by default.' "$file"
+  done
   for file in config/claude/CLAUDE.md config/copilot/AGENTS.md; do
     grep -Fq 'Development-and-Releases.md' "$file"
     grep -Fq 'scripts/check.sh all' "$file"
@@ -1124,7 +1132,7 @@ run_apollo_smoke() {
   grep -Fq 'ZSH_THEME=apollo' config/zsh/custom.zsh
   grep -Fq 'FAST_WORK_DIR' config/zsh/custom.zsh
   grep -Fq $'link\tconfig/zsh/themes/apollo.zsh-theme\t.oh-my-zsh/custom/themes/apollo.zsh-theme' config/manifest.tsv
-  jq -e 'has("theme") | not' config/claude/settings.json >/dev/null
+  jq -e '.theme == "custom:apollo"' config/claude/settings.json >/dev/null
   jq -e '.theme == "default"' config/copilot/settings.json >/dev/null
 
   if grep -En '#[0-9a-fA-F]{6}|38;2;|48;2;' \

--- a/wiki/Claude-Code-zh-CN.md
+++ b/wiki/Claude-Code-zh-CN.md
@@ -43,13 +43,13 @@ Relay 路由：     gptModel
 | `claude-opus-5[1m]` | `opusModel` | `claude-opus-5` |
 | Haiku / small-fast aliases | `gptModel` | `gpt-6-astra` |
 
-`[1m]` 后缀让 Claude Code 使用一百万 token 的 context 计数；relay 向上游发送规范 ID `gpt-6-astra`。保持 `autoCompactWindow: 800000`，为 Astra 的 1M 总窗口内公布的 872,000-token prompt 上限预留余量。Relay 端 thinking 在 `config/copilot-relay/config.yaml` 中设为 `max`。
+`[1m]` 后缀让 Claude Code 使用一百万 token 的模型 context 计数；relay 向上游发送规范 ID `gpt-6-astra`。自动压缩刻意在 75,000 tokens 时触发，远早于 Astra 的 1M 总窗口内公布的 872,000-token prompt 上限。这并不意味着会保留完整的 1M-token 对话历史。Relay 端 thinking 在 `config/copilot-relay/config.yaml` 中设为 `max`。
 
 使用本设置前，请先使用支持 GPT-6 Astra 的 relay 构建（见 [copilot-relay issue #57](https://github.com/D0n9X1n/copilot-relay/issues/57)）。修改模型时应同时更新 `config/claude/settings.json`、`config/zsh/claude.zsh` 和 `config/zsh/cc.zsh`；wrapper 的 `--model` 优先于设置文件。Relay 的 `gptModel` 不带后缀，空白的 `webSearchBackend` 也使用 Astra。Opus 路由保持独立。
 
 切换模型前，运行 `copilot` 并输入 `/model`，检查账号可用性和 effort 选项。这是 Copilot 的选择器，不是 Claude Code 的选择器，也不是 relay 本地的 `/v1/models`。`scripts/check.sh all` 通过后，运行两次 `./install.sh` 应用配置，再启动新的 shell 和 Claude Code 会话。安装器会重启 relay，可能中断正在进行的请求；请先等待请求结束。
 
-Sonnet 和 Opus 是两个模型家族。任务只要求修改一个家族时，不要同时修改两个。
+Sonnet-facing 槽位通过 `gptModel` 路由到 GPT-6 Astra；Opus 仍使用独立的 `opusModel` 路由。任务只要求修改一条路由时，不要同时修改两条。
 
 ## 主要设置
 
@@ -63,19 +63,32 @@ Sonnet 和 Opus 是两个模型家族。任务只要求修改一个家族时，�
 | `MODEL_REASONING_EFFORT` | `max`；启动器同时传入 `--effort max` |
 | `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` | `16` |
 | `statusLine.refreshInterval` | `100` |
-| UI 主题 | 本机 `custom:apollo`，在 `~/.claude.json` 中选择 |
-| `autoCompactWindow` | `800000` |
+| `theme` | `custom:apollo`；生成的主题资源仍保留在本机 |
+| `autoCompactEnabled` | `true` |
+| `autoCompactWindow` | `120000`，尚未扣除输出 token 预留量 |
+| `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | `"75"`；默认输出预算下在 75,000 tokens 时触发压缩 |
+| `feedbackDrafts` | `off` |
 
-`refreshInterval` 必须放在 `statusLine` 里面。
+`refreshInterval` 必须放在 `statusLine` 里面。Max effort 保留在环境变量和启动器 flag 中：Claude Code 2.1.261 不接受在持久化的顶层 `effortLevel` 设置中填写 `max`。
+
+### 75k 自动压缩
+
+Claude Code 2.1.261 要求 `autoCompactWindow` 至少为 100,000，因此不能直接设置为 `75000`。受管配置采用 120,000-token 窗口和 `env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: "75"`。默认输出预算下，Claude 先预留 20,000 tokens：`(120000 - 20000) × 75% = 75000`。
+
+使用这些受管设置、且未覆盖输出预算的隔离 CLI 运行报告了 `effective_window: 100000`、`threshold: 75000` 和 `enforced: true`，没有发送上游请求。这是触发阈值，不是对话大小的硬上限；某一轮可能先越过阈值，再执行压缩。修改模型、输出预算或 `CLAUDE_CODE_AUTO_COMPACT_WINDOW` 覆盖值可能改变计算结果。编辑源设置后请启动新的 Claude Code 会话。
 
 `~/.claude/settings.json` 和 `~/.claude.json` 是不同文件：
 
-- `settings.json` 是链接的配置。
-- `~/.claude.json` 是本机状态。它保存 onboarding、API key 允许项、选中的 Apollo 主题、项目数据和导入的 MCP servers。
+- `settings.json` 是链接的配置，包括 `custom:apollo` 主题偏好。
+- `~/.claude.json` 是本机状态。它保存 onboarding、API key 允许项、安装器同步选择的 Apollo 主题、项目数据和导入的 MCP servers。
 
 `install.sh` 会从已验证的规范 Apollo release 生成 `~/.claude/themes/apollo.json`，并在选择 `custom:apollo` 时保留所有无关字段。生成主题是本机状态，不是 Git 源文件。
 
 不要把本机状态文件放进 Git。
+
+## 全局指令
+
+`config/claude/CLAUDE.md` 安装为 `~/.claude/CLAUDE.md`，并设置用户级回复风格。对话文字默认直接、简短。明确要求更多细节时仍按要求回答；代码、命令、检查结果、证据、必要说明、安全信息和技术准确性必须保持完整。
 
 ## 启动器
 
@@ -88,6 +101,8 @@ Sonnet 和 Opus 是两个模型家族。任务只要求修改一个家族时，�
 ```
 
 二进制会拒绝 settings 中的 `permissions.defaultMode: bypassPermissions`。命令行 flag 可以工作。Claude Code 可能在运行时重写 settings，所以 wrapper 也固定模型和 effort。
+
+`settings.json` 是符号链接，因此 CLI 持久化的偏好可能表现为源文件改动。提交前检查 `git diff -- config/claude/settings.json`，只按上面的受支持设置核对变动的键，再运行 `scripts/check.sh all`。不要整份恢复文件，以免丢失其他有意保留的修改。
 
 `cc [标题]` 会设置 SonicTerm 标题，在 RMUX 中重命名窗口，并用相同默认值启动 Claude Code。
 
@@ -124,6 +139,7 @@ Claude 与 Copilot 状态栏共享五行布局、本机生成的 Apollo 颜色�
 
 - `frontend-design@claude-plugins-official`
 - `rust-analyzer-lsp@claude-plugins-official`
+- `clangd-lsp@claude-plugins-official`
 - `claude-code-wakatime@wakatime`
 
 WakaTime marketplace 指向官方 `wakatime/claude-code-wakatime` Git 仓库。

--- a/wiki/Claude-Code-zh-CN.md
+++ b/wiki/Claude-Code-zh-CN.md
@@ -27,11 +27,11 @@ Claude Code 第一次启动时会问是否允许自定义 `dummy` API key。请�
 受管默认值：
 
 ```text
-Claude 端名称： claude-sonnet-5[1m]
-Picker 名称：    Sonnet 5
+Claude 端名称： gpt-6-astra[1m]
+Picker 名称：    GPT-6 Astra
 客户端 effort：  max
 Relay 路由：     gptModel
-上游模型：       gpt-5.6-sol
+上游模型：       gpt-6-astra
 ```
 
 名称中没有 `opus`，所以 copilot-relay 会把它发送到 `gptModel`。
@@ -41,9 +41,13 @@ Relay 路由：     gptModel
 | Claude 端名称 | Relay lane | 上游 |
 |---|---|---|
 | `claude-opus-5[1m]` | `opusModel` | `claude-opus-5` |
-| Haiku / small-fast aliases | `gptModel` | `gpt-5.6-sol` |
+| Haiku / small-fast aliases | `gptModel` | `gpt-6-astra` |
 
-`[1m]` 后缀让 Claude Code 使用一百万 token 的 context 计数。Relay 端 thinking 在 `config/copilot-relay/config.yaml` 中设为 `max`。
+`[1m]` 后缀让 Claude Code 使用一百万 token 的 context 计数；relay 向上游发送规范 ID `gpt-6-astra`。保持 `autoCompactWindow: 800000`，为 Astra 的 1M 总窗口内公布的 872,000-token prompt 上限预留余量。Relay 端 thinking 在 `config/copilot-relay/config.yaml` 中设为 `max`。
+
+使用本设置前，请先使用支持 GPT-6 Astra 的 relay 构建（见 [copilot-relay issue #57](https://github.com/D0n9X1n/copilot-relay/issues/57)）。修改模型时应同时更新 `config/claude/settings.json`、`config/zsh/claude.zsh` 和 `config/zsh/cc.zsh`；wrapper 的 `--model` 优先于设置文件。Relay 的 `gptModel` 不带后缀，空白的 `webSearchBackend` 也使用 Astra。Opus 路由保持独立。
+
+切换模型前，运行 `copilot` 并输入 `/model`，检查账号可用性和 effort 选项。这是 Copilot 的选择器，不是 Claude Code 的选择器，也不是 relay 本地的 `/v1/models`。`scripts/check.sh all` 通过后，运行两次 `./install.sh` 应用配置，再启动新的 shell 和 Claude Code 会话。安装器会重启 relay，可能中断正在进行的请求；请先等待请求结束。
 
 Sonnet 和 Opus 是两个模型家族。任务只要求修改一个家族时，不要同时修改两个。
 
@@ -55,8 +59,8 @@ Sonnet 和 Opus 是两个模型家族。任务只要求修改一个家族时，�
 |---|---|
 | `ANTHROPIC_BASE_URL` | `http://127.0.0.1:4142` |
 | `ANTHROPIC_AUTH_TOKEN` | 本机占位符 `dummy` |
-| `ANTHROPIC_MODEL` | `claude-sonnet-5[1m]` |
-| `effortLevel` | `max` |
+| `ANTHROPIC_MODEL` | `gpt-6-astra[1m]` |
+| `MODEL_REASONING_EFFORT` | `max`；启动器同时传入 `--effort max` |
 | `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` | `16` |
 | `statusLine.refreshInterval` | `100` |
 | UI 主题 | 本机 `custom:apollo`，在 `~/.claude.json` 中选择 |
@@ -79,7 +83,7 @@ Sonnet 和 Opus 是两个模型家族。任务只要求修改一个家族时，�
 
 ```text
 --permission-mode bypassPermissions
---model claude-sonnet-5[1m]
+--model gpt-6-astra[1m]
 --effort max
 ```
 
@@ -136,7 +140,7 @@ WakaTime marketplace 指向官方 `wakatime/claude-code-wakatime` Git 仓库。
 
 ### 小任务出现 `model_not_supported`
 
-保持 Haiku 和 small-fast aliases 都是 `gpt-5.6-sol[1m]`。同时检查 relay base URL。
+保持 Haiku 和 small-fast aliases 都是 `gpt-6-astra[1m]`。同时检查 relay base URL。
 
 ### Relay 重写 settings
 

--- a/wiki/Claude-Code.md
+++ b/wiki/Claude-Code.md
@@ -27,11 +27,11 @@ The first Claude Code launch asks if the custom `dummy` API key is allowed. Choo
 The tracked default is:
 
 ```text
-Claude-facing name: claude-sonnet-5[1m]
-Picker name:        Sonnet 5
+Claude-facing name: gpt-6-astra[1m]
+Picker name:        GPT-6 Astra
 Client effort:      max
 Relay route:        gptModel
-Upstream model:     gpt-5.6-sol
+Upstream model:     gpt-6-astra
 ```
 
 The name has no `opus`, so copilot-relay sends it to `gptModel`.
@@ -41,9 +41,13 @@ Other routes:
 | Claude-facing name | Relay lane | Upstream |
 |---|---|---|
 | `claude-opus-5[1m]` | `opusModel` | `claude-opus-5` |
-| Haiku / small-fast aliases | `gptModel` | `gpt-5.6-sol` |
+| Haiku / small-fast aliases | `gptModel` | `gpt-6-astra` |
 
-The `[1m]` suffix keeps Claude Code's one-million-token context accounting. Relay-side thinking is `max` in `config/copilot-relay/config.yaml`.
+The `[1m]` suffix keeps Claude Code's one-million-token context accounting; the relay sends canonical `gpt-6-astra` upstream. Keep `autoCompactWindow: 800000` to leave room below Astra's advertised 872,000-token prompt limit within its 1M total window. Relay-side thinking is `max` in `config/copilot-relay/config.yaml`.
+
+Use a relay build with GPT-6 Astra support before relying on this setup (tracked in [copilot-relay issue #57](https://github.com/D0n9X1n/copilot-relay/issues/57)). Update the model in `config/claude/settings.json`, `config/zsh/claude.zsh`, and `config/zsh/cc.zsh` together; the wrappers' `--model` overrides the settings. The relay's `gptModel` stays suffix-free. Its blank `webSearchBackend` also uses Astra. Keep the Opus route separate.
+
+Run `copilot` and enter `/model` to check account availability and effort choices before changing models. That is Copilot's picker, not Claude Code's picker or the relay's local `/v1/models`. After `scripts/check.sh all` passes, apply through `./install.sh` twice and start a new shell and Claude Code session. The installer restarts the relay and may interrupt active requests; wait for them to finish first.
 
 Sonnet and Opus are separate families. Do not change both when a task asks to update one family.
 
@@ -55,8 +59,8 @@ Sonnet and Opus are separate families. Do not change both when a task asks to up
 |---|---|
 | `ANTHROPIC_BASE_URL` | `http://127.0.0.1:4142` |
 | `ANTHROPIC_AUTH_TOKEN` | local placeholder `dummy` |
-| `ANTHROPIC_MODEL` | `claude-sonnet-5[1m]` |
-| `effortLevel` | `max` |
+| `ANTHROPIC_MODEL` | `gpt-6-astra[1m]` |
+| `MODEL_REASONING_EFFORT` | `max`; launch wrappers also pass `--effort max` |
 | `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` | `16` |
 | `statusLine.refreshInterval` | `100` |
 | UI theme | local `custom:apollo`, selected in `~/.claude.json` |
@@ -79,7 +83,7 @@ Do not put the local state file in Git.
 
 ```text
 --permission-mode bypassPermissions
---model claude-sonnet-5[1m]
+--model gpt-6-astra[1m]
 --effort max
 ```
 
@@ -136,7 +140,7 @@ The first prompt was answered no. In local `~/.claude.json`, move `dummy` from `
 
 ### Small jobs get `model_not_supported`
 
-Keep both Haiku and small-fast aliases set to `gpt-5.6-sol[1m]`. Also check the relay base URL.
+Keep both Haiku and small-fast aliases set to `gpt-6-astra[1m]`. Also check the relay base URL.
 
 ### Relay rewrites settings
 

--- a/wiki/Claude-Code.md
+++ b/wiki/Claude-Code.md
@@ -43,13 +43,13 @@ Other routes:
 | `claude-opus-5[1m]` | `opusModel` | `claude-opus-5` |
 | Haiku / small-fast aliases | `gptModel` | `gpt-6-astra` |
 
-The `[1m]` suffix keeps Claude Code's one-million-token context accounting; the relay sends canonical `gpt-6-astra` upstream. Keep `autoCompactWindow: 800000` to leave room below Astra's advertised 872,000-token prompt limit within its 1M total window. Relay-side thinking is `max` in `config/copilot-relay/config.yaml`.
+The `[1m]` suffix keeps Claude Code's one-million-token model context accounting; the relay sends canonical `gpt-6-astra` upstream. Automatic compaction deliberately starts at 75,000 tokens, well before Astra's advertised 872,000-token prompt limit within its 1M total window. This does not retain a full 1M-token conversation history. Relay-side thinking is `max` in `config/copilot-relay/config.yaml`.
 
 Use a relay build with GPT-6 Astra support before relying on this setup (tracked in [copilot-relay issue #57](https://github.com/D0n9X1n/copilot-relay/issues/57)). Update the model in `config/claude/settings.json`, `config/zsh/claude.zsh`, and `config/zsh/cc.zsh` together; the wrappers' `--model` overrides the settings. The relay's `gptModel` stays suffix-free. Its blank `webSearchBackend` also uses Astra. Keep the Opus route separate.
 
 Run `copilot` and enter `/model` to check account availability and effort choices before changing models. That is Copilot's picker, not Claude Code's picker or the relay's local `/v1/models`. After `scripts/check.sh all` passes, apply through `./install.sh` twice and start a new shell and Claude Code session. The installer restarts the relay and may interrupt active requests; wait for them to finish first.
 
-Sonnet and Opus are separate families. Do not change both when a task asks to update one family.
+The Sonnet-facing slot routes to GPT-6 Astra through `gptModel`; Opus stays on its separate `opusModel` route. Do not change both routes when a task names only one.
 
 ## Main settings
 
@@ -63,19 +63,32 @@ Sonnet and Opus are separate families. Do not change both when a task asks to up
 | `MODEL_REASONING_EFFORT` | `max`; launch wrappers also pass `--effort max` |
 | `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` | `16` |
 | `statusLine.refreshInterval` | `100` |
-| UI theme | local `custom:apollo`, selected in `~/.claude.json` |
-| `autoCompactWindow` | `800000` |
+| `theme` | `custom:apollo`; generated theme assets stay local |
+| `autoCompactEnabled` | `true` |
+| `autoCompactWindow` | `120000` before the output-token reserve |
+| `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | `"75"`; triggers compaction at 75,000 tokens with the default output budget |
+| `feedbackDrafts` | `off` |
 
-`refreshInterval` belongs inside `statusLine`.
+`refreshInterval` belongs inside `statusLine`. Keep max effort in the environment and launcher flags: Claude Code 2.1.261 does not accept `max` in the persisted top-level `effortLevel` setting.
+
+### 75k automatic compaction
+
+Claude Code 2.1.261 requires `autoCompactWindow` to be at least 100,000, so setting it to `75000` is invalid. The tracked combination is a 120,000-token window and `env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: "75"`. With the default output budget, Claude reserves 20,000 tokens first: `(120000 - 20000) × 75% = 75000`.
+
+An isolated run of the installed CLI, using these tracked settings and no output-budget override, reported `effective_window: 100000`, `threshold: 75000`, and `enforced: true`. No upstream request was made. This sets a trigger, not a hard transcript-size cap; a turn can cross it before compaction runs. Changing the model, output budget, or `CLAUDE_CODE_AUTO_COMPACT_WINDOW` override can change the calculation. Start a new Claude Code session after editing the source settings.
 
 `~/.claude/settings.json` and `~/.claude.json` are different files:
 
-- `settings.json` is linked config.
-- `~/.claude.json` is local state. It holds onboarding, API-key approval, the selected Apollo theme, project data, and imported MCP servers.
+- `settings.json` is linked config, including the `custom:apollo` theme preference.
+- `~/.claude.json` is local state. It holds onboarding, API-key approval, the installer's matching Apollo theme selection, project data, and imported MCP servers.
 
 `install.sh` generates `~/.claude/themes/apollo.json` from the verified canonical Apollo release and preserves every unrelated field when it selects `custom:apollo`. The generated theme is local state, not a Git source.
 
 Do not put the local state file in Git.
+
+## Global instructions
+
+`config/claude/CLAUDE.md` installs as `~/.claude/CLAUDE.md` and sets user-wide response style. Conversational prose is direct and concise by default. Requests for more detail still win, and code, commands, findings, evidence, caveats, safety information, and technical precision stay complete.
 
 ## Launch wrappers
 
@@ -88,6 +101,8 @@ Do not put the local state file in Git.
 ```
 
 The binary rejects `permissions.defaultMode: bypassPermissions` in settings. The command-line flag works. The wrapper also pins model and effort because Claude Code can rewrite settings at runtime.
+
+Because `settings.json` is a symlink, CLI-persisted preferences can appear as source changes. Review `git diff -- config/claude/settings.json` before committing, reconcile only the changed keys with the supported settings above, and rerun `scripts/check.sh all`. Do not restore the whole file and lose other intentional edits.
 
 `cc [title]` sets the SonicTerm title, renames the RMUX window when present, and starts Claude Code with the same defaults.
 
@@ -124,6 +139,7 @@ The tracked settings enable:
 
 - `frontend-design@claude-plugins-official`
 - `rust-analyzer-lsp@claude-plugins-official`
+- `clangd-lsp@claude-plugins-official`
 - `claude-code-wakatime@wakatime`
 
 The WakaTime marketplace points to the official `wakatime/claude-code-wakatime` Git repository.

--- a/wiki/Copilot-CLI-zh-CN.md
+++ b/wiki/Copilot-CLI-zh-CN.md
@@ -9,13 +9,17 @@ Copilot CLI 文件在 `config/copilot/`。它们安装到 `~/.copilot/`。
 `config/copilot/settings.json` 使用：
 
 ```text
-model:       claude-opus-5
+model:       gpt-6-astra
 context:     long_context
 effort:      max
 theme:       default（终端 Base-16）
 keep alive:  busy
 streaming:   on
 ```
+
+运行 `copilot`，然后在其交互会话中输入 `/model`，即可查看账号可用模型及其 effort 选项。Astra 公布的档位为 `low`、`medium`、`high`、`xhigh`、`max`；可用性取决于账号和组织策略。CLI 使用规范 ID `gpt-6-astra`，不带 Claude Code 的 `[1m]` 后缀。
+
+修改受管默认值时，应同时编辑 `config/copilot/settings.json` 和 `config/zsh/gg.zsh` 中的 `--model`，然后运行 `scripts/check.sh all`。非受管安装可通过 `/config model` 修改 Copilot 用户默认值；本仓库应修改受版本控制的源文件，避免下次安装覆盖选择。
 
 自定义 footer 隐藏内置字段，并运行 `~/.copilot/statusline.sh`。
 
@@ -53,7 +57,7 @@ copilot          # 普通 Copilot wrapper
 gg my-project    # 带标题、不限制工具和路径的 Copilot session
 ```
 
-`gg` 使用 Opus 5、长 context 和 max effort。它也会传入 `--allow-all-tools --allow-all-paths`，所以工具和路径不会请求允许。不想使用这种访问模式时，请使用普通 `copilot`。
+`gg` 使用 GPT-6 Astra、长 context 和 max effort。它也会传入 `--allow-all-tools --allow-all-paths`，所以工具和路径不会请求允许。不想使用这种访问模式时，请使用普通 `copilot`。
 
 `gg` 会向 SonicTerm 发送 OSC 标题。它在 RMUX 中也会运行 `rmux rename-window`。它不会调用 tmux 或 WezTerm CLI。
 

--- a/wiki/Copilot-CLI-zh-CN.md
+++ b/wiki/Copilot-CLI-zh-CN.md
@@ -32,7 +32,9 @@ Copilot 安装两个指令文件：
 - `config/copilot/copilot-instructions.md` → `~/.copilot/copilot-instructions.md`
 - `config/copilot/AGENTS.md` → `~/.copilot/AGENTS.md`
 
-原生文件保存 Copilot 的用户级行为。`AGENTS.md` 指向 Wiki，用于可复用的 GitHub Wiki 和 release 工作。
+原生文件保存 Copilot 的用户级行为。它让对话文字默认直接、简短。明确要求更多细节时仍按要求回答；代码、命令、检查结果、证据、必要说明、安全信息和技术准确性必须保持完整。
+
+`AGENTS.md` 只保留 Wiki 指针，用于可复用的 GitHub Wiki 和 release 工作。
 
 `config/zsh/custom.zsh` 把 `~/.copilot` 加入 `COPILOT_CUSTOM_INSTRUCTIONS_DIRS`。它会保留已有路径，也不会重复添加。
 

--- a/wiki/Copilot-CLI.md
+++ b/wiki/Copilot-CLI.md
@@ -32,7 +32,9 @@ Copilot has two installed instruction files:
 - `config/copilot/copilot-instructions.md` → `~/.copilot/copilot-instructions.md`
 - `config/copilot/AGENTS.md` → `~/.copilot/AGENTS.md`
 
-The native file keeps Copilot's user-wide behavior. `AGENTS.md` points to the Wiki for reusable GitHub Wiki and release work.
+The native file keeps Copilot's user-wide behavior. It makes conversational prose direct and concise by default. Requests for more detail still win, and code, commands, findings, evidence, caveats, safety information, and technical precision stay complete.
+
+`AGENTS.md` stays focused on the Wiki pointer for reusable GitHub Wiki and release work.
 
 `config/zsh/custom.zsh` adds `~/.copilot` to `COPILOT_CUSTOM_INSTRUCTIONS_DIRS`. It keeps any paths that already exist and does not add a duplicate.
 

--- a/wiki/Copilot-CLI.md
+++ b/wiki/Copilot-CLI.md
@@ -9,13 +9,17 @@ Copilot CLI files live under `config/copilot/`. They install under `~/.copilot/`
 `config/copilot/settings.json` uses:
 
 ```text
-model:       claude-opus-5
+model:       gpt-6-astra
 context:     long_context
 effort:      max
 theme:       default (terminal Base-16)
 keep alive:  busy
 streaming:   on
 ```
+
+Run `copilot`, then enter `/model` inside its interactive session to see your account's available models and their effort choices. Astra advertises `low`, `medium`, `high`, `xhigh`, and `max`; availability depends on the account and organization policy. The CLI uses canonical `gpt-6-astra`, without Claude Code's `[1m]` suffix.
+
+To change the managed default, edit `config/copilot/settings.json` and the `--model` in `config/zsh/gg.zsh` together, then run `scripts/check.sh all`. For an unmanaged installation, `/config model` changes the Copilot user default; here, edit the tracked sources so the next install does not undo your choice.
 
 The custom footer hides built-in fields and runs `~/.copilot/statusline.sh`.
 
@@ -53,7 +57,7 @@ copilot          # normal Copilot wrapper
 gg my-project    # titled, unrestricted Copilot session
 ```
 
-`gg` uses Opus 5, long context, and max effort. It also passes `--allow-all-tools --allow-all-paths`, so tools and paths do not ask for approval. Use plain `copilot` when you do not want that access mode.
+`gg` uses GPT-6 Astra, long context, and max effort. It also passes `--allow-all-tools --allow-all-paths`, so tools and paths do not ask for approval. Use plain `copilot` when you do not want that access mode.
 
 `gg` sends OSC title codes to SonicTerm. Inside RMUX, it also runs `rmux rename-window`. It does not call tmux or the WezTerm CLI.
 

--- a/wiki/RMUX-zh-CN.md
+++ b/wiki/RMUX-zh-CN.md
@@ -130,7 +130,7 @@ set -s set-clipboard on
 
 ```sh
 rmux claude --permission-mode bypassPermissions \
-  --model 'claude-sonnet-5[1m]' --effort max
+  --model 'gpt-6-astra[1m]' --effort max
 ```
 
 `rmux claude` 会启用 Claude Code 的 tmux teammate mode，并在 Claude 进程的 `PATH` 前加入私有、进程级的 `tmux` shim，使 teammate 命令指向 RMUX。它不会替换系统全局的 `tmux`。本仓库不会运行 `rmux setup tmux-shim`。

--- a/wiki/RMUX.md
+++ b/wiki/RMUX.md
@@ -130,7 +130,7 @@ Use normal `claude` or the repository's `cc` helper for an ordinary Claude Code 
 
 ```sh
 rmux claude --permission-mode bypassPermissions \
-  --model 'claude-sonnet-5[1m]' --effort max
+  --model 'gpt-6-astra[1m]' --effort max
 ```
 
 `rmux claude` enables Claude Code's tmux teammate mode and prepends a private, process-scoped `tmux` shim so Claude's teammate commands target RMUX. It does not replace the global `tmux` executable. This repository deliberately does not run `rmux setup tmux-shim`.

--- a/wiki/Services-and-Automation-zh-CN.md
+++ b/wiki/Services-and-Automation-zh-CN.md
@@ -52,7 +52,7 @@ http://127.0.0.1:4142
 ```yaml
 claudeSetup: false
 thinkEffort: max
-gptModel: gpt-5.6-sol
+gptModel: gpt-6-astra
 opusModel: claude-opus-5
 ```
 

--- a/wiki/Services-and-Automation.md
+++ b/wiki/Services-and-Automation.md
@@ -52,7 +52,7 @@ Important values:
 ```yaml
 claudeSetup: false
 thinkEffort: max
-gptModel: gpt-5.6-sol
+gptModel: gpt-6-astra
 opusModel: claude-opus-5
 ```
 


### PR DESCRIPTION
## Summary

- Default Copilot CLI and the managed relay to canonical `gpt-6-astra`; align Claude Code, its aliases, and launch wrappers on `gpt-6-astra[1m]` without changing the separate Opus route or max reasoning effort.
- Bring all existing local work together: concise-response instructions for Claude/Copilot, clangd, disabled feedback drafts, enabled auto-compaction, and the Apollo theme preference. Remove unsupported persisted `effortLevel: max`, retaining the environment and launcher flags.
- Configure an enforced 75,000-token compaction trigger using `autoCompactWindow: 120000` and `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: "75"`; synchronize English/Chinese discovery, settings, service, and RMUX Wiki guidance and checks.

Closes #20
Closes #22
Closes #23

## Dependency

Relay support is released in [copilot-relay v0.3.4](https://github.com/D0n9X1n/copilot-relay/releases/tag/v0.3.4), via [PR #58](https://github.com/D0n9X1n/copilot-relay/pull/58) (related issue: D0n9X1n/copilot-relay#57).

## Validation

- [x] `scripts/check.sh all` on the complete combined tree, again after both installer passes: exit 0. Includes Apollo, models/wrappers, bilingual Wiki graph and publish scripts, RMUX, and ShellCheck.
- [x] Installed Claude Code 2.1.261, isolated initialization using the tracked compaction settings with the default output budget: `enabled: true`, `effective_window: 100000`, `threshold: 75000`, `enforced: true`, `source: settings`; no HTTP requests.
- [x] Cross-family spec/code review: no critical findings; nonblocking symlink write-back concern addressed with safe, key-by-key recovery guidance in both languages. Source-policy checks remain explicit.
- [x] Ran `install.sh` twice successfully. Managed Claude, Copilot, and relay links verified; all three launchd jobs loaded; installed and running relay report 0.3.4.
- [x] Live Copilot catalog confirmed Astra and its supported efforts and advertised context limits during the companion relay work.
- [x] Final CI on c5ce230: macOS smoke and Ubuntu ShellCheck passed.
- [x] Released v2.3.1 at 6cfc49c; release notes match the exact three commits since v2.3.0. Wiki publish succeeded on the merge SHA; all 27 source pages match the live transform and all 24 English/Chinese home navigation links were exercised in a browser. Merged feature and stale clean worktree branches removed; remote retains only main.

## Notes

Astra's 1M model identity is retained, but normal conversation history deliberately compacts at 75k. The threshold is not a hard transcript-size cap and depends on the CLI's output reserve; the Wiki explains the tested 120k minus 20k, times 75% calculation. Existing permissions and authentication settings are unchanged. No secrets or runtime files are committed.

Cost: 4 dot-config-related dispatches, multiple resumed work periods, models: Sonnet 5, Opus 5.

Generated with [Claude Code](https://claude.com/claude-code)


Release: https://github.com/D0n9X1n/dot-config/releases/tag/v2.3.1

Installation verification: both installer passes exited 0, model/compaction links and all launchd jobs verified. An actual Astra request returned OK with max_tokens 256. The relay CLI diagnostic at 16 tokens reported an empty response after exhausting its reasoning budget; separately tracked in D0n9X1n/copilot-relay#59 rather than misreported as an auth failure.

