### PR TITLE
Align global assistant settings and Apollo status colors

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,12 +14,19 @@ The Wiki is the full source of truth for this repo. Do not copy its full help in
 
 `config/manifest.tsv` is the install list. A new managed file needs a manifest row.
 
-Tool-required files stay at their fixed paths:
+Tool-required files stay at fixed paths: `.claude/CLAUDE.md`, `.github/copilot-instructions.md`, `.github/workflows/*.yml`, `.gitignore`.
 
-- `.claude/CLAUDE.md`
-- `.github/copilot-instructions.md`
-- `.github/workflows/*.yml`
-- `.gitignore`
+## Instruction scope
+
+`config/` holds the globally synced config for every project. Globals keep reusable behavior plus one conditional pointer back here. Anything repo-only stays in this file.
+
+## Model policy
+
+Keep native client names. Claude Code uses `claude-sonnet-5[1m]` and `claude-haiku-4-5-20251001`.
+
+The relay maps every non-Opus route through `gptModel` to `gpt-6-astra`. Opus stays separate as `claude-opus-5`.
+
+Do not replace a client identity with GPT. Never put a GPT id or a display override name back into Claude settings. Keep Sonnet and Opus model families separate.
 
 ## Before an edit
 
@@ -33,13 +40,9 @@ Read the matching Wiki page:
 - services: `wiki/Services-and-Automation.md`
 - checks and release: `wiki/Development-and-Releases.md`
 
-Keep English and `-zh-CN` Wiki pages together.
+Keep English and `-zh-CN` Wiki pages together. Keep the root README short.
 
-Keep the status-line layout and cache aligned. Preserve the documented provider metrics and live-subagent differences.
-
-Keep Sonnet and Opus model families separate.
-
-Launchd files under `config/launchd/` are templates. Run `install.sh` to render them.
+Keep the status-line layout and cache aligned. Preserve the documented provider metrics and live-subagent differences. Launchd files under `config/launchd/` are templates; run `install.sh` to render them.
 
 ## Check
 
@@ -51,8 +54,6 @@ For a config change, run `./install.sh` twice after checks pass. Then verify the
 
 ## Safety
 
-This repo is public.
-
-Do not commit tokens, keys, auth files, logs, runtime state, SonicTerm save locks, or `.claude/worktrees/`.
+This repo is public. Do not commit tokens, keys, auth files, logs, runtime state, SonicTerm save locks, or `.claude/worktrees/`.
 
 Do not force-push. Do not use `--no-verify` unless the user asks.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,21 +14,41 @@ The Wiki is the full source of truth for this repo. Do not copy its full help in
 
 `config/manifest.tsv` is the install list. A new managed file needs a manifest row.
 
-Read the matching Wiki page before an edit. Use `wiki/Development-and-Releases.md` for checks, Wiki publish, issues, tags, and releases.
+Tool-required files stay at fixed paths: `.claude/CLAUDE.md`, `.github/copilot-instructions.md`, `.github/workflows/*.yml`, `.gitignore`.
+
+## Instruction scope
+
+`config/` holds the globally synced config for every project. Globals keep reusable behavior plus one conditional pointer back here. Anything repo-only stays in this file.
+
+## Model policy
+
+Keep native client names. Claude Code uses `claude-sonnet-5[1m]` and `claude-haiku-4-5-20251001`.
+
+The relay maps every non-Opus route through `gptModel` to `gpt-6-astra`. Opus stays separate as `claude-opus-5`.
+
+Do not replace a client identity with GPT. Never put a GPT id or a display override name back into Claude settings. Keep Sonnet and Opus model families separate.
+
+Copilot CLI keeps its own `gpt-6-astra` settings. Do not align it with the Claude client ids.
+
+## Before an edit
+
+Read the matching Wiki page. Use `wiki/Development-and-Releases.md` for checks, Wiki publish, issues, tags, and releases.
 
 Keep English and `-zh-CN` pages together. Keep the root README short.
 
-Keep the status-line layout and cache aligned. Preserve the documented provider metrics and live-subagent differences. Keep Sonnet and Opus model families separate.
+Keep the status-line layout and cache aligned. Preserve the documented provider metrics and live-subagent differences.
 
 Launchd files under `config/launchd/` are templates. Run `install.sh` to render them.
 
-Run:
+## Check
 
 ```sh
 scripts/check.sh all
 ```
 
 For config changes, run `./install.sh` twice after checks pass.
+
+## Safety
 
 This repo is public. Do not commit tokens, keys, auth files, logs, runtime state, SonicTerm save locks, or `.claude/worktrees/`.
 

--- a/config/claude/CLAUDE.md
+++ b/config/claude/CLAUDE.md
@@ -13,21 +13,8 @@
 
 Do not use ASCII-art flowcharts in Markdown. Use a fenced Mermaid diagram.
 
-## dot-config guide
+## Managed settings
 
-For work on `D0n9X1n/dot-config`, read `wiki/README.md` first. The Wiki is the full source of truth.
+These global settings are synced from `~/Public/dot-configs`.
 
-The local reference is:
-
-```text
-~/Public/dot-configs/wiki/Development-and-Releases.md
-```
-
-Use it for source-controlled GitHub Wiki pipelines and commit-derived release pipelines. Follow the target repo's own rules first.
-
-For dot-config changes:
-
-- keep English and `-zh-CN` Wiki pages together;
-- keep the root README short;
-- run `scripts/check.sh all` before push;
-- do not commit secrets or runtime files.
+When you change these settings, edit the tracked config sources there and read that folder's `.claude/CLAUDE.md` first.

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -2,12 +2,10 @@
   "env": {
     "ANTHROPIC_BASE_URL": "http://127.0.0.1:4142",
     "ANTHROPIC_AUTH_TOKEN": "dummy",
-    "ANTHROPIC_MODEL": "gpt-6-astra[1m]",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "gpt-6-astra[1m]",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME": "GPT-6 Astra",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION": "GPT-6 Astra (1M context) through copilot-relay",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gpt-6-astra[1m]",
-    "ANTHROPIC_SMALL_FAST_MODEL": "gpt-6-astra[1m]",
+    "ANTHROPIC_MODEL": "claude-sonnet-5[1m]",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-5[1m]",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-haiku-4-5-20251001",
+    "ANTHROPIC_SMALL_FAST_MODEL": "claude-haiku-4-5-20251001",
     "MODEL_REASONING_EFFORT": "max",
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "75",
     "CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS": "16"
@@ -16,7 +14,7 @@
     "allow": [],
     "defaultMode": "auto"
   },
-  "model": "gpt-6-astra[1m]",
+  "model": "sonnet",
   "statusLine": {
     "type": "command",
     "command": "~/.claude/statusline.sh",
@@ -40,7 +38,7 @@
   "feedbackDrafts": "off",
   "autoCompactWindow": 120000,
   "skipDangerousModePermissionPrompt": true,
+  "theme": "custom:apollo",
   "autoCompactEnabled": true,
-  "skipAutoPermissionPrompt": true,
-  "theme": "custom:apollo"
+  "skipAutoPermissionPrompt": true
 }

--- a/config/claude/skills/update-settings/SKILL.md
+++ b/config/claude/skills/update-settings/SKILL.md
@@ -51,9 +51,11 @@ Keep provider metrics different: Claude shows cost; Copilot shows premium reques
 
 Sonnet and Opus are separate families.
 
-- Sonnet-facing names route to `gptModel`.
-- Opus names route to `opusModel`.
-- Keep `[1m]` on Claude-facing defaults that need one-million-token accounting.
+- Claude Code keeps native client ids: `claude-sonnet-5[1m]` and `claude-haiku-4-5-20251001`.
+- Sonnet-facing names route through `gptModel` to `gpt-6-astra`.
+- Opus names route to `opusModel` and stay `claude-opus-5`.
+- Keep `[1m]` on Claude-facing defaults that need one-million-token accounting. The Haiku id takes no suffix.
+- Do not put a GPT id, or a `_NAME` / `_DESCRIPTION` display override, into Claude settings.
 
 Do not change both families when the task names one.
 
@@ -78,9 +80,9 @@ Plists under `config/launchd/` are templates.
 
 ### Global instructions
 
-Keep `config/claude/CLAUDE.md` and `config/copilot/AGENTS.md` short. They point to `wiki/Development-and-Releases.md`.
+Keep `config/claude/CLAUDE.md`, `config/copilot/AGENTS.md`, and `config/copilot/copilot-instructions.md` short. They hold reusable behavior plus one conditional pointer: these settings are synced from `~/Public/dot-configs`, and a change to them starts by reading that folder's own instruction file. Repo-only rules stay in this repo's `.claude/CLAUDE.md` and `.github/copilot-instructions.md`, so an unrelated project never loads them.
 
-Copilot's native entry file is `config/copilot/copilot-instructions.md`. `config/zsh/custom.zsh` keeps `~/.copilot` in `COPILOT_CUSTOM_INSTRUCTIONS_DIRS`.
+Copilot's native entry file is `config/copilot/copilot-instructions.md`. It names `~/.copilot/AGENTS.md` by absolute path and repeats the settings-source pointer, because Copilot does not reliably inline the global `AGENTS.md`. `config/zsh/custom.zsh` keeps `~/.copilot` in `COPILOT_CUSTOM_INSTRUCTIONS_DIRS`; that wiring is asserted by `scripts/check.sh instructions`, not repeated in the instruction text.
 
 ## Update help
 

--- a/config/copilot/AGENTS.md
+++ b/config/copilot/AGENTS.md
@@ -1,18 +1,7 @@
-# Global GitHub publishing guide
+# Global agent instructions
 
-For work on `D0n9X1n/dot-config`, read `wiki/README.md` first. The Wiki is the full source of truth.
+## Managed settings
 
-The local reference is:
+These global settings are synced from `~/Public/dot-configs`.
 
-```text
-~/Public/dot-configs/wiki/Development-and-Releases.md
-```
-
-Use it for source-controlled GitHub Wiki pipelines and commit-derived release pipelines. Follow the target repo's own rules first.
-
-For dot-config changes:
-
-- keep English and `-zh-CN` Wiki pages together;
-- keep the root README short;
-- run `scripts/check.sh all` before push;
-- do not commit secrets or runtime files.
+When you change these settings, edit the tracked config sources there and read that folder's `.github/copilot-instructions.md` first.

--- a/config/copilot/copilot-instructions.md
+++ b/config/copilot/copilot-instructions.md
@@ -9,8 +9,13 @@
 - Preserve necessary caveats, evidence, safety information, and technical precision.
 - Use headings or other structure when they improve clarity.
 
+## Working rules
+
 - Run tools and commands without asking for approval.
 - Work on the task directly.
-- Read `AGENTS.md` for the global publishing pointer.
-- For `D0n9X1n/dot-config`, read `wiki/README.md` first.
-- The shell adds `~/.copilot` to `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` so this file and `AGENTS.md` load together.
+
+## Managed settings
+
+These global settings are synced from `~/Public/dot-configs`.
+
+`~/.copilot/AGENTS.md` holds the same pointer. When you change these settings, edit the tracked config sources in that folder and read its `.github/copilot-instructions.md` first.

--- a/config/copilot/statusline.sh
+++ b/config/copilot/statusline.sh
@@ -146,12 +146,14 @@ ICON_SUBAGENT=$'\xef\x83\x90'
 ICON_MODE=$'\xef\x82\x85'
 
 C_RESET=""; C_DIM=""; C_RED=""; C_GREEN=""; C_YELLOW=""; C_BLUE=""
-C_PURPLE=""; C_AQUA=""; C_ORANGE=""; C_FG=""; C_FG_DIM=""
+C_PURPLE=""; C_AQUA=""; C_ORANGE=""; C_FG=""; C_FG_DIM=""; C_FG_BRIGHT=""
 APOLLO_STATUSLINE_COLORS="${HOME}/.local/share/dot-configs/apollo/current/generated/statusline-colors.sh"
 if [ -z "${COPILOT_STATUSLINE_NO_COLOR:-}" ] && [ -z "${COPILOT_STATUSLINE_NO_DIM:-}" ] && \
     [ -f "$APOLLO_STATUSLINE_COLORS" ]; then
   source "$APOLLO_STATUSLINE_COLORS"
 fi
+# Existing bundles may not yet export the bright foreground role.
+[ -n "$C_FG_BRIGHT" ] || C_FG_BRIGHT="$C_FG"
 
 # Per-side padding emitted from inside the script. Copilot CLI's
 # statusLine.padding* fields are silently ignored — only the single
@@ -320,9 +322,6 @@ fi
 
 # --- 3. Helpers ------------------------------------------------------------
 label() {
-  # "<color><icon> <Label> <reset>" — icon + label share the segment's
-  # accent color; the value (printed by the segment after this returns)
-  # uses C_FG so it reads as the bright eye-catcher.
   local color="$1" icon="$2" text="$3"
   if [ "$ICONS_ON" = "1" ]; then
     printf '%s%s %s%s ' "$color" "$icon" "$text" "$C_RESET"
@@ -407,12 +406,12 @@ seg_model() {
         s/  +/ /g
         s/ +$//
       ')"
-  printf '%s%s%s%s' "$(label "$C_AQUA" "$ICON_MODEL" 'Model')" "$C_FG" "$short" "$C_RESET"
+  printf '%s%s%s%s' "$(label "$C_YELLOW" "$ICON_MODEL" 'Model')" "$C_FG_BRIGHT" "$short" "$C_RESET"
 }
 
 seg_effort() {
   [ -n "$effort_level" ] || return 0
-  printf '%s%s%s%s' "$(label "$C_PURPLE" "$ICON_EFFORT" 'Effort')" "$C_FG" "$effort_level" "$C_RESET"
+  printf '%s%s%s%s' "$(label "$C_PURPLE" "$ICON_EFFORT" 'Effort')" "$C_FG_BRIGHT" "$effort_level" "$C_RESET"
 }
 
 seg_timer() {
@@ -428,7 +427,7 @@ seg_timer() {
   is_pos_int "$started" || started="$now"
   elapsed=$((now - started))
   [ "$elapsed" -ge 60 ] || return 0
-  printf '%s%s%s%s' "$(label "$C_ORANGE" "$ICON_RUN" 'Run')" "$C_FG" "$(fmt_dhm "$elapsed")" "$C_RESET"
+  printf '%s%s%s%s' "$(label "$C_PURPLE" "$ICON_RUN" 'Run')" "$C_FG" "$(fmt_dhm "$elapsed")" "$C_RESET"
 }
 
 seg_wall() {
@@ -494,7 +493,7 @@ seg_ctx() {
   fi
   local body
   if [ -n "$ctx_size" ] && [ "$ctx_size" != "null" ]; then
-    body="${color}${pct_int}%${C_RESET}${C_DIM}/$(fmt_tokens "$ctx_size")${C_RESET}"
+    body="${color}${pct_int}%${C_RESET}${C_FG_DIM}/$(fmt_tokens "$ctx_size")${C_RESET}"
   else
     body="${color}${pct_int}%${C_RESET}"
   fi
@@ -510,7 +509,7 @@ seg_path() {
     "$HOME") p="~" ;;
     "$HOME"/*) p="~${p#$HOME}" ;;
   esac
-  printf '%s%s%s%s' "$(label "$C_ORANGE" "$ICON_PATH" 'Path')" "$C_FG" "$p" "$C_RESET"
+  printf '%s%s%s%s' "$(label "$C_AQUA" "$ICON_PATH" 'Path')" "$C_FG_BRIGHT" "$p" "$C_RESET"
 }
 
 # Vim / Style — Copilot CLI doesn't currently surface equivalent runtime
@@ -706,7 +705,7 @@ seg_branch() {
   if [ ${#br} -gt 24 ]; then
     br="${br:0:23}…"
   fi
-  printf '%s%s%s%s' "$(label "$C_YELLOW" "$ICON_BRANCH" 'Branch')" "$C_FG" "$br" "$C_RESET"
+  printf '%s%s%s%s' "$(label "$C_YELLOW" "$ICON_BRANCH" 'Branch')" "$C_FG_BRIGHT" "$br" "$C_RESET"
 }
 
 seg_stash() {
@@ -1187,7 +1186,7 @@ for s in $SEGMENTS; do
   part="$("seg_$s" 2>/dev/null || true)"
   [ -n "$part" ] || continue
   if [ "$line_started" = 1 ]; then
-    out="${out}${C_DIM}${SEP}${C_RESET}${part}"
+    out="${out}${C_FG_DIM}${SEP}${C_RESET}${part}"
   else
     out="${out}${part}"
     line_started=1

--- a/config/zsh/cc.zsh
+++ b/config/zsh/cc.zsh
@@ -34,6 +34,6 @@ function cc {
   if [[ -n "$RMUX" ]] && (( $+commands[rmux] )); then
     command rmux rename-window -- "$title" 2>/dev/null
   fi
-  command claude --permission-mode bypassPermissions --model 'gpt-6-astra[1m]' --effort max
+  command claude --permission-mode bypassPermissions --model 'claude-sonnet-5[1m]' --effort max
   unset DISABLE_AUTO_TITLE
 }

--- a/config/zsh/claude.zsh
+++ b/config/zsh/claude.zsh
@@ -28,7 +28,7 @@ function claude {
   done
 
   defaults=(--permission-mode bypassPermissions)
-  (( has_model )) || defaults+=(--model 'gpt-6-astra[1m]')
+  (( has_model )) || defaults+=(--model 'claude-sonnet-5[1m]')
   (( has_effort )) || defaults+=(--effort max)
 
   command claude "${defaults[@]}" "$@"

--- a/install.sh
+++ b/install.sh
@@ -972,6 +972,49 @@ install_copilot_relay_healthcheck() {
   fi
 }
 
+# Local MCP definitions replace user definitions rather than inheriting headers.
+warn_claude_github_mcp_overrides() {
+  local claude_user_json="${HOME}/.claude.json"
+  local projects project
+
+  have_cmd jq || return 0
+  [ -f "$claude_user_json" ] || return 0
+
+  projects="$(jq -r '
+      def github_http:
+        type == "object" and .type == "http"
+        and ((.url // "") | sub("/$"; "")) == "https://api.githubcopilot.com/mcp";
+      def auth_values:
+        [(.headers // {}) | to_entries[]
+         | select((.key | ascii_downcase) == "authorization")
+         | .value | select(type == "string")];
+      def delegated:
+        (keys_unsorted | map(ascii_downcase) | any(startswith("oauth")))
+        or has("headersHelper");
+      (.mcpServers.github // {}) as $global
+      | if ($global | github_http)
+          and ($global | auth_values | any(test("^Bearer[[:space:]]+[^[:space:]]+"; "i"))) then
+          (.projects // {}) | to_entries[]
+          | (.value.mcpServers.github // {}) as $local
+          | select($local | github_http)
+          | select($local | auth_values | any(test("[^[:space:]]")) | not)
+          | select($local | delegated | not)
+          | .key | @json
+        else empty end
+    ' "$claude_user_json" 2>/dev/null)" || {
+    printf '%s\n' 'Warning: could not inspect Claude local state for GitHub MCP overrides.'
+    return 0
+  }
+
+  [ -n "$projects" ] || return 0
+  while IFS= read -r project; do
+    printf 'Warning: local GitHub MCP entry for %s has no auth header and shadows the user entry with a configured Bearer token.\n' "$project"
+    printf '%s\n' '         Review the override. If unintended, run in that project: claude mcp remove github --scope local; then reconnect.'
+  done <<EOF
+$projects
+EOF
+}
+
 if [ "${DOT_CONFIGS_INSTALL_LIB_ONLY:-0}" = "1" ]; then
   return 0 2>/dev/null || exit 0
 fi
@@ -1078,6 +1121,8 @@ if have_cmd jq && [ -f "$copilot_mcp" ]; then
     fi
   fi
 fi
+
+warn_claude_github_mcp_overrides
 
 # launchd agent: copilot-relay on login (macOS only). Renders the
 # template (substituting absolute $HOME paths — launchd doesn't expand

--- a/scripts/apollo-theme.sh
+++ b/scripts/apollo-theme.sh
@@ -250,6 +250,7 @@ apollo_generate_statusline_colors() {
   apollo_append_ansi C_ORANGE fg "$(apollo_color "$palette" accent)" "$output"
   apollo_append_ansi C_FG fg "$(apollo_color "$palette" foreground)" "$output"
   apollo_append_ansi C_FG_DIM fg "$(apollo_color "$palette" foregroundInactive)" "$output"
+  apollo_append_ansi C_FG_BRIGHT fg "$(apollo_color "$palette" foregroundBright)" "$output"
   apollo_append_ansi CB_RED bg "$(apollo_color "$palette" danger)" "$output"
   apollo_append_ansi CB_BLUE bg "$(apollo_color "$palette" info)" "$output"
   apollo_append_ansi CB_YELLOW bg "$(apollo_color "$palette" accent)" "$output"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -179,24 +179,40 @@ SH
 }
 
 run_model_default_smoke() {
-  # Claude Code: GPT-6 Astra is the startup identity; "[1m]" keeps
-  # one-million-token client context accounting while relay strips it upstream.
   jq -e '
-    .env.ANTHROPIC_MODEL == "gpt-6-astra[1m]" and
-    .model == "gpt-6-astra[1m]" and
+    .env.ANTHROPIC_MODEL == "claude-sonnet-5[1m]" and
+    .model == "sonnet" and
     (has("effortLevel") | not) and
     .env.MODEL_REASONING_EFFORT == "max" and
-    .env.ANTHROPIC_DEFAULT_SONNET_MODEL == "gpt-6-astra[1m]" and
-    .env.ANTHROPIC_DEFAULT_SONNET_MODEL_NAME == "GPT-6 Astra" and
-    .env.ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION == "GPT-6 Astra (1M context) through copilot-relay" and
-    .env.ANTHROPIC_DEFAULT_HAIKU_MODEL == "gpt-6-astra[1m]" and
-    .env.ANTHROPIC_SMALL_FAST_MODEL == "gpt-6-astra[1m]" and
+    .env.ANTHROPIC_DEFAULT_SONNET_MODEL == "claude-sonnet-5[1m]" and
+    (.env | has("ANTHROPIC_DEFAULT_SONNET_MODEL_NAME") | not) and
+    (.env | has("ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION") | not) and
+    .env.ANTHROPIC_DEFAULT_HAIKU_MODEL == "claude-haiku-4-5-20251001" and
+    .env.ANTHROPIC_SMALL_FAST_MODEL == "claude-haiku-4-5-20251001" and
+    .env.ANTHROPIC_BASE_URL == "http://127.0.0.1:4142" and
+    .env.CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS == "16" and
     .autoCompactEnabled == true and
     .autoCompactWindow == 120000 and
     .env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE == "75" and
     .feedbackDrafts == "off" and
+    .skipDangerousModePermissionPrompt == true and
+    .skipAutoPermissionPrompt == true and
+    .theme == "custom:apollo" and
+    .permissions.defaultMode == "auto" and
+    .statusLine.command == "~/.claude/statusline.sh" and
     .enabledPlugins["clangd-lsp@claude-plugins-official"] == true
   ' config/claude/settings.json >/dev/null
+
+  # No GPT identity may leak back into any Claude-facing selector or label.
+  if jq -e '
+      [(.env | to_entries[] | select(.key | test("^ANTHROPIC_.*MODEL")) | .value),
+       .model]
+      | map(select(type == "string") | ascii_downcase)
+      | any(test("gpt"))
+    ' config/claude/settings.json >/dev/null; then
+    echo "config/claude/settings.json carries a GPT identity on a Claude selector" >&2
+    return 1
+  fi
 
   # Copilot CLI: GPT-6 Astra at the 1M context tier and max effort.
   jq -e '
@@ -214,11 +230,283 @@ run_model_default_smoke() {
 
   # Launcher wrappers inject the same defaults (settings.json can be rewritten
   # at runtime, so the flags are the authoritative per-launch pin).
-  grep -Fq -- "--model 'gpt-6-astra[1m]'" config/zsh/claude.zsh
-  grep -Fq -- "--model 'gpt-6-astra[1m]' --effort max" config/zsh/cc.zsh
+  grep -Fq -- "--model 'claude-sonnet-5[1m]'" config/zsh/claude.zsh
+  grep -Fq -- "--model 'claude-sonnet-5[1m]' --effort max" config/zsh/cc.zsh
   grep -Fq -- "--model gpt-6-astra --context long_context --effort max" config/zsh/gg.zsh
+  if grep -Fq 'gpt-6-astra' config/zsh/claude.zsh config/zsh/cc.zsh; then
+    echo "Claude launchers must not pin a GPT model id" >&2
+    return 1
+  fi
 
-  echo "model defaults ok: GPT-6 Astra @ max effort, 1M context"
+  # The `claude` wrapper injects native defaults but yields to explicit flags.
+  (
+    local test_root fake_bin capture args
+    test_root="$(mktemp -d)"
+    trap 'rm -rf "$test_root"' EXIT
+    fake_bin="$test_root/bin"
+    capture="$test_root/capture"
+    mkdir -p "$fake_bin"
+    cat >"$fake_bin/claude" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$CLAUDE_CAPTURE"
+SH
+    chmod +x "$fake_bin/claude"
+
+    PATH="$fake_bin:$PATH" CLAUDE_CAPTURE="$capture" \
+      zsh -c 'source config/zsh/claude.zsh; claude'
+    args="$(sed -n '1p' "$capture")"
+    case "$args" in
+      *"--model claude-sonnet-5[1m]"*) : ;;
+      *) echo "claude wrapper default lost the native Sonnet pin: $args" >&2; exit 1 ;;
+    esac
+    case "$args" in
+      *'--effort max'*) : ;;
+      *) echo "claude wrapper default lost --effort max: $args" >&2; exit 1 ;;
+    esac
+    case "$args" in
+      *'--permission-mode bypassPermissions'*) : ;;
+      *) echo "claude wrapper default lost bypassPermissions: $args" >&2; exit 1 ;;
+    esac
+
+    : >"$capture"
+    PATH="$fake_bin:$PATH" CLAUDE_CAPTURE="$capture" \
+      zsh -c 'source config/zsh/claude.zsh; claude --model opus'
+    args="$(sed -n '1p' "$capture")"
+    case "$args" in
+      *'claude-sonnet-5'*) echo "explicit --model was overridden: $args" >&2; exit 1 ;;
+    esac
+
+    : >"$capture"
+    PATH="$fake_bin:$PATH" CLAUDE_CAPTURE="$capture" \
+      zsh -c 'source config/zsh/claude.zsh; claude --model=opus'
+    args="$(sed -n '1p' "$capture")"
+    case "$args" in
+      *'claude-sonnet-5'*) echo "explicit --model= was overridden: $args" >&2; exit 1 ;;
+    esac
+
+    : >"$capture"
+    PATH="$fake_bin:$PATH" CLAUDE_CAPTURE="$capture" \
+      zsh -c 'source config/zsh/claude.zsh; claude --effort low'
+    args="$(sed -n '1p' "$capture")"
+    case "$args" in
+      *'--effort max'*) echo "explicit --effort was overridden: $args" >&2; exit 1 ;;
+    esac
+    case "$args" in
+      *"--model claude-sonnet-5[1m]"*) : ;;
+      *) echo "explicit --effort dropped the model default: $args" >&2; exit 1 ;;
+    esac
+  )
+
+  echo "model defaults ok: native Sonnet/Haiku client ids, relay maps non-Opus to GPT-6 Astra"
+}
+
+run_claude_github_mcp_warning_smoke() {
+  local test_root maker secret out digest_before digest_after case_dir case_output
+  test_root="$(mktemp -d)"
+  trap 'rm -rf "${test_root:-}"' RETURN
+  secret='ghu_FAKE_NOT_A_REAL_TOKEN_0123456789'
+  maker="$test_root/make-case.py"
+  out="$test_root/out.log"
+  : >"$out"
+
+  cat >"$maker" <<'PY'
+import json
+import os
+import sys
+
+case, root, secret = sys.argv[1], sys.argv[2], sys.argv[3]
+endpoint = "https://api.githubcopilot.com/mcp"
+os.makedirs(root, exist_ok=True)
+path = os.path.join(root, ".claude.json")
+
+
+def http_github(url=endpoint, headers=None, extra=None):
+    server = {"type": "http", "url": url}
+    if headers is not None:
+        server["headers"] = headers
+    if extra:
+        server.update(extra)
+    return server
+
+
+def authed(name="Authorization"):
+    return {"mcpServers": {"github": http_github(headers={name: "Bearer " + secret})}}
+
+
+weird_path = '/tmp/pro j\nsecond"q\\z'
+doc = None
+raw = None
+
+if case == "headerless":
+    doc = authed()
+    doc["projects"] = {"/tmp/proj-a": {"mcpServers": {"github": http_github()}}}
+elif case == "empty_headers":
+    doc = authed()
+    doc["projects"] = {"/tmp/proj-b": {"mcpServers": {"github": http_github(headers={})}}}
+elif case == "whitespace_auth":
+    doc = authed()
+    doc["projects"] = {
+        "/tmp/proj-c": {"mcpServers": {"github": http_github(headers={"Authorization": "   \t "})}}
+    }
+elif case == "lowercase_global":
+    doc = authed(name="authorization")
+    doc["projects"] = {"/tmp/proj-d": {"mcpServers": {"github": http_github()}}}
+elif case == "trailing_slash":
+    doc = {"mcpServers": {"github": http_github(url=endpoint + "/", headers={"Authorization": "Bearer " + secret})}}
+    doc["projects"] = {"/tmp/proj-e": {"mcpServers": {"github": http_github()}}}
+elif case == "weird_path":
+    doc = authed()
+    doc["projects"] = {weird_path: {"mcpServers": {"github": http_github()}}}
+elif case == "no_github_global":
+    doc = {"mcpServers": {"other": http_github()}}
+    doc["projects"] = {"/tmp/proj-f": {"mcpServers": {"github": http_github()}}}
+elif case == "unauthenticated_global":
+    doc = {"mcpServers": {"github": http_github()}}
+    doc["projects"] = {"/tmp/proj-g": {"mcpServers": {"github": http_github()}}}
+elif case == "non_bearer_global":
+    doc = {"mcpServers": {"github": http_github(headers={"Authorization": "Basic " + secret})}}
+    doc["projects"] = {"/tmp/proj-basic": {"mcpServers": {"github": http_github()}}}
+elif case == "empty_bearer_global":
+    doc = {"mcpServers": {"github": http_github(headers={"Authorization": "Bearer   "})}}
+    doc["projects"] = {"/tmp/proj-empty": {"mcpServers": {"github": http_github()}}}
+elif case == "authenticated_local":
+    doc = authed()
+    doc["projects"] = {
+        "/tmp/proj-h": {"mcpServers": {"github": http_github(headers={"Authorization": "Bearer " + secret})}}
+    }
+elif case == "lowercase_local":
+    doc = authed()
+    doc["projects"] = {"/tmp/proj-lower": {"mcpServers": {"github": http_github(headers={"authorization": "Bearer " + secret})}}}
+elif case == "different_url":
+    doc = authed()
+    doc["projects"] = {
+        "/tmp/proj-i": {"mcpServers": {"github": http_github(url="https://example.invalid/mcp")}}
+    }
+elif case == "oauth":
+    doc = authed()
+    doc["projects"] = {
+        "/tmp/proj-j": {"mcpServers": {"github": http_github(extra={"oauth": {"clientId": "x"}})}}
+    }
+elif case == "headers_helper":
+    doc = authed()
+    doc["projects"] = {
+        "/tmp/proj-k": {"mcpServers": {"github": http_github(extra={"headersHelper": "/bin/echo"})}}
+    }
+elif case == "no_projects":
+    doc = authed()
+elif case == "malformed":
+    raw = '{"mcpServers": {"github": {"type": "http", ' + secret + '\n'
+else:
+    raise SystemExit("unknown case: " + case)
+
+with open(path, "w", encoding="utf-8") as handle:
+    if raw is not None:
+        handle.write(raw)
+    else:
+        json.dump(doc, handle)
+        handle.write("\n")
+
+if case == "weird_path":
+    with open(os.path.join(root, "expected.txt"), "w", encoding="utf-8") as handle:
+        handle.write(json.dumps(weird_path) + "\n")
+PY
+
+  run_case() {
+    local case_name="$1"
+    local dir="$test_root/$case_name"
+    [ -f "$dir/.claude.json" ] || python3 "$maker" "$case_name" "$dir" "$secret" || return 1
+    cp "$dir/.claude.json" "$dir/before.json" || return 1
+    (
+      HOME="$dir"
+      DOT_CONFIGS_INSTALL_LIB_ONLY=1 source install.sh || exit 1
+      warn_claude_github_mcp_overrides
+    ) >"$test_root/$case_name.out" 2>"$test_root/$case_name.err" || return 1
+    cmp -s "$dir/before.json" "$dir/.claude.json" || {
+      echo "GitHub MCP warning changed state for case: $case_name" >&2
+      return 1
+    }
+    cat "$test_root/$case_name.out" "$test_root/$case_name.err" >>"$out"
+    cat "$test_root/$case_name.out" "$test_root/$case_name.err"
+  }
+
+  # Warns: an unauthenticated local override shadows the authenticated global.
+  for case_dir in headerless empty_headers whitespace_auth lowercase_global trailing_slash; do
+    if ! run_case "$case_dir" | grep -Fq 'claude mcp remove github --scope local'; then
+      echo "expected a github MCP override warning for case: $case_dir" >&2
+      return 1
+    fi
+  done
+  run_case headerless | grep -Fq '"/tmp/proj-a"'
+
+  # Silent: nothing to warn about, or the override is deliberate.
+  for case_dir in no_github_global unauthenticated_global non_bearer_global empty_bearer_global \
+      authenticated_local lowercase_local different_url oauth headers_helper no_projects; do
+    case_output="$(run_case "$case_dir")" || return 1
+    if [ -n "$case_output" ]; then
+      echo "unexpected github MCP warning for case: $case_dir" >&2
+      return 1
+    fi
+  done
+
+  # A project path with a newline or quote stays on one escaped line.
+  run_case weird_path >/dev/null
+  if ! grep -Fq "$(cat "$test_root/weird_path/expected.txt")" "$test_root/weird_path.out"; then
+    echo "project path was not JSON-escaped in the warning" >&2
+    return 1
+  fi
+  [ "$(grep -Fc 'claude mcp remove github --scope local' "$test_root/weird_path.out")" = "1" ]
+
+  # Malformed JSON: one generic diagnostic, never a dump of the file.
+  run_case malformed >/dev/null
+  if ! cat "$test_root/malformed.out" "$test_root/malformed.err" | grep -Fq 'could not inspect'; then
+    echo "malformed .claude.json did not produce a generic diagnostic" >&2
+    return 1
+  fi
+
+  # Missing state file and missing jq are both silent successes.
+  mkdir -p "$test_root/absent" "$test_root/nojq-bin"
+  if [ -n "$(
+      HOME="$test_root/absent"
+      DOT_CONFIGS_INSTALL_LIB_ONLY=1 source install.sh
+      warn_claude_github_mcp_overrides 2>&1
+    )" ]; then
+    echo "missing ~/.claude.json must stay silent" >&2
+    return 1
+  fi
+  (
+    HOME="$test_root/headerless"
+    DOT_CONFIGS_INSTALL_LIB_ONLY=1 source install.sh
+    # Assignment clears Bash 3.2's command cache; a function-prefix override does not.
+    PATH="$test_root/nojq-bin"
+    warn_claude_github_mcp_overrides
+  ) >"$test_root/nojq.out" 2>"$test_root/nojq.err"
+  if [ -s "$test_root/nojq.out" ] || [ -s "$test_root/nojq.err" ]; then
+    echo "missing jq must stay silent" >&2
+    return 1
+  fi
+
+  # Read-only and idempotent: bytes never change, output repeats exactly.
+  digest_before="$(shasum -a 256 "$test_root/headerless/.claude.json" | awk '{print $1}')"
+  run_case headerless >"$test_root/first.txt"
+  run_case headerless >"$test_root/second.txt"
+  digest_after="$(shasum -a 256 "$test_root/headerless/.claude.json" | awk '{print $1}')"
+  [ "$digest_before" = "$digest_after" ] || {
+    echo "github MCP inspection modified ~/.claude.json" >&2
+    return 1
+  }
+  cmp -s "$test_root/first.txt" "$test_root/second.txt" || {
+    echo "github MCP warning is not idempotent" >&2
+    return 1
+  }
+
+  # The bearer token never reaches stdout or stderr.
+  if grep -Fq "$secret" "$out" "$test_root/first.txt" "$test_root/second.txt"; then
+    echo "github MCP warning leaked an authorization value" >&2
+    return 1
+  fi
+
+  unset -f run_case
+  echo "claude github MCP override warning ok: read-only, escaped, secret-free"
 }
 
 run_copilot_terminal_smoke() {
@@ -252,27 +540,39 @@ SH
 }
 
 run_global_instructions_smoke() {
-  local file lines
-  local files=(
+  local file lines pattern
+  local project_files=(
     .claude/CLAUDE.md
     .github/copilot-instructions.md
+  )
+  local global_files=(
     config/claude/CLAUDE.md
     config/copilot/AGENTS.md
     config/copilot/copilot-instructions.md
   )
 
-  for file in "${files[@]}"; do
+  for file in "${project_files[@]}" "${global_files[@]}"; do
     [ -f "$file" ] || {
       echo "missing instruction source: $file" >&2
       return 1
     }
-    grep -Fq 'wiki/README.md' "$file"
   done
 
-  for file in .claude/CLAUDE.md .github/copilot-instructions.md; do
+  for file in "${project_files[@]}"; do
+    grep -Fq 'wiki/README.md' "$file"
     grep -Fq 'config/manifest.tsv' "$file"
     grep -Fq 'scripts/check.sh all' "$file"
     grep -Fq 'full source of truth' "$file"
+    grep -Fq -- '-zh-CN' "$file"
+    grep -Fq 'root README' "$file"
+    grep -Fq 'globally synced' "$file"
+    grep -Fq 'repo-only' "$file"
+    grep -Fq 'claude-sonnet-5' "$file"
+    grep -Fq 'claude-haiku-4-5-20251001' "$file"
+    grep -Fq 'gptModel' "$file"
+    grep -Fq 'gpt-6-astra' "$file"
+    grep -Fq 'claude-opus-5' "$file"
+    grep -Fq 'display override' "$file"
     lines="$(wc -l <"$file" | tr -d ' ')"
     [ "$lines" -le 60 ] || {
       echo "$file must stay short" >&2
@@ -283,20 +583,45 @@ run_global_instructions_smoke() {
   grep -Fq 'Do not use ASCII-art flowcharts' config/claude/CLAUDE.md
   for file in config/claude/CLAUDE.md config/copilot/copilot-instructions.md; do
     grep -Fq 'Keep conversational prose concise by default.' "$file"
+    grep -Fq 'Lead with the answer.' "$file"
+    grep -Fq 'Match detail to the' "$file"
+    grep -Fq 'Keep code, commands, diffs' "$file"
+    grep -Fq 'Preserve necessary caveats' "$file"
+    grep -Fq 'Use headings or other structure' "$file"
   done
-  for file in config/claude/CLAUDE.md config/copilot/AGENTS.md; do
-    grep -Fq 'Development-and-Releases.md' "$file"
-    grep -Fq 'scripts/check.sh all' "$file"
+  for file in "${global_files[@]}"; do
+    grep -Fq '~/Public/dot-configs' "$file"
+    for pattern in \
+      'wiki/README.md' \
+      'Development-and-Releases' \
+      'scripts/check.sh' \
+      '-zh-CN' \
+      'root README' \
+      'D0n9X1n/dot-config'; do
+      if grep -Fq -e "$pattern" "$file"; then
+        echo "$file must not carry repo-only directive: $pattern" >&2
+        return 1
+      fi
+    done
+    if grep -Eq '^@' "$file"; then
+      echo "$file must not use an @import" >&2
+      return 1
+    fi
     lines="$(wc -l <"$file" | tr -d ' ')"
     [ "$lines" -le 40 ] || {
-      echo "$file must point to the Wiki instead of copying it" >&2
+      echo "$file must stay a short global" >&2
       return 1
     }
   done
 
   grep -Fq 'Run tools and commands without asking for approval.' config/copilot/copilot-instructions.md
-  grep -Fq 'AGENTS.md' config/copilot/copilot-instructions.md
-  grep -Fq 'COPILOT_CUSTOM_INSTRUCTIONS_DIRS' config/copilot/copilot-instructions.md
+  grep -Fq 'Work on the task directly.' config/copilot/copilot-instructions.md
+  # Copilot does not reliably inline the global AGENTS.md.
+  grep -Fq '~/.copilot/AGENTS.md' config/copilot/copilot-instructions.md
+  if grep -Fq 'COPILOT_CUSTOM_INSTRUCTIONS_DIRS' config/copilot/copilot-instructions.md; then
+    echo "config/copilot/copilot-instructions.md must not carry loader internals" >&2
+    return 1
+  fi
 
   zsh -f -c '
     unset COPILOT_CUSTOM_INSTRUCTIONS_DIRS
@@ -326,11 +651,15 @@ run_global_instructions_smoke() {
     printf 'original global instructions\n' >"$test_home/.claude/CLAUDE.md"
     printf 'tracked Claude instructions\n' >"$test_repo/config/claude/CLAUDE.md"
     printf 'tracked Copilot instructions\n' >"$test_repo/config/copilot/AGENTS.md"
+    printf 'tracked native Copilot instructions\n' \
+      >"$test_repo/config/copilot/copilot-instructions.md"
 
     HOME="$test_home"
     timestamp="20000101000000"
     link_file "$test_repo/config/claude/CLAUDE.md" "$test_home/.claude/CLAUDE.md"
     link_file "$test_repo/config/copilot/AGENTS.md" "$test_home/.copilot/AGENTS.md"
+    link_file "$test_repo/config/copilot/copilot-instructions.md" \
+      "$test_home/.copilot/copilot-instructions.md"
 
     [ -L "$test_home/.claude/CLAUDE.md" ]
     [ "$(readlink "$test_home/.claude/CLAUDE.md")" = "$test_repo/config/claude/CLAUDE.md" ]
@@ -338,9 +667,12 @@ run_global_instructions_smoke() {
     grep -Fq 'original global instructions' "$test_home/.claude/CLAUDE.md.bak.20000101000000"
     [ -L "$test_home/.copilot/AGENTS.md" ]
     [ "$(readlink "$test_home/.copilot/AGENTS.md")" = "$test_repo/config/copilot/AGENTS.md" ]
+    [ -L "$test_home/.copilot/copilot-instructions.md" ]
+    [ "$(readlink "$test_home/.copilot/copilot-instructions.md")" \
+      = "$test_repo/config/copilot/copilot-instructions.md" ]
   )
 
-  echo "global Claude/Copilot Wiki pointers ok"
+  echo "global/project instruction scope, native model policy, and links ok"
 }
 
 run_wiki_smoke() {
@@ -1364,6 +1696,120 @@ SH
     return 1
   fi
 
+  local colors_file payload old_home pct code rows
+  colors_file="$test_home/.local/share/dot-configs/apollo/current/generated/statusline-colors.sh"
+  grep -Fq "C_FG_BRIGHT=" "$colors_file" || {
+    echo "generated statusline colors are missing C_FG_BRIGHT" >&2
+    return 1
+  }
+  (
+    # shellcheck disable=SC1090
+    . "$colors_file"
+    [ "$C_FG_BRIGHT" = "$(printf '\033[38;2;0;0;8m')" ] || {
+      echo "C_FG_BRIGHT was not generated from foregroundBright" >&2
+      exit 1
+    }
+    [ "$C_FG" = "$(printf '\033[38;2;0;0;5m')" ]
+    [ "$C_FG_DIM" = "$(printf '\033[38;2;0;0;7m')" ]
+  )
+
+  # Selected segments use the bright role for values; labels keep their roles.
+  payload='{"model":{"display_name":"Claude Sonnet 4.5 (max)"},"workspace":{"current_dir":"'"$test_home"'"},"context_window":{"used_percentage":50,"context_window_size":100000}}'
+  out="$(printf '%s' "$payload" | HOME="$test_home" \
+    COPILOT_STATUSLINE_NO_ICONS=1 \
+    COPILOT_STATUSLINE_SEGMENTS='model effort ctx \n path' \
+    bash config/copilot/statusline.sh)"
+  printf '%s' "$out" | grep -Fq $'\033[38;2;0;0;9mModel\033[0m \033[38;2;0;0;8mSonnet 4.5\033[0m' || {
+    echo "Model segment lost the yellow label / bright value styling" >&2
+    return 1
+  }
+  printf '%s' "$out" | grep -Fq $'\033[38;2;0;0;13mEffort\033[0m \033[38;2;0;0;8mmax\033[0m' || {
+    echo "Effort segment lost the bright value styling" >&2
+    return 1
+  }
+  printf '%s' "$out" | grep -Fq $'\033[38;2;0;0;14mPath\033[0m \033[38;2;0;0;8m~\033[0m' || {
+    echo "Path segment lost the aqua label / bright value styling" >&2
+    return 1
+  }
+  # Capacity suffix and ordinary separators use the dim foreground, not C_DIM.
+  printf '%s' "$out" | grep -Fq $'\033[38;2;0;0;7m/100k\033[0m' || {
+    echo "context capacity is not using the dim foreground role" >&2
+    return 1
+  }
+  printf '%s' "$out" | grep -Fq $'\033[38;2;0;0;7m │ \033[0m' || {
+    echo "ordinary separators are not using the dim foreground role" >&2
+    return 1
+  }
+  if printf '%s' "$out" | grep -Fq $'\033[2m'; then
+    echo "ordinary status-line row still emits the bare C_DIM attribute" >&2
+    return 1
+  fi
+
+  # Numeric context boundaries keep green / yellow / red.
+  while IFS=' ' read -r pct code; do
+    [ -n "$pct" ] || continue
+    out="$(printf '{"context_window":{"used_percentage":%s}}' "$pct" | HOME="$test_home" \
+      COPILOT_STATUSLINE_NO_ICONS=1 COPILOT_STATUSLINE_SEGMENTS='ctx' \
+      bash config/copilot/statusline.sh)"
+    printf '%s' "$out" | grep -Fq "$(printf '\033[38;2;0;0;%sm%s%%' "$code" "$pct")" || {
+      echo "context color boundary changed at ${pct}%" >&2
+      return 1
+    }
+  done <<'BOUNDS'
+49 11
+50 9
+80 10
+BOUNDS
+
+  # A file preserves the trailing newline of an empty last row.
+  printf '%s' "$payload" | HOME="$test_home" bash config/copilot/statusline.sh \
+    >"$test_root/default-line.txt"
+  rows="$(tr -dc '\n' <"$test_root/default-line.txt" | wc -c | tr -d ' ')"
+  [ "$rows" = "4" ] || {
+    echo "default Copilot status line is no longer five rows (separators: $rows)" >&2
+    return 1
+  }
+
+  # No-color, legacy no-dim, and a missing include all stay plain text.
+  for mode in COPILOT_STATUSLINE_NO_COLOR COPILOT_STATUSLINE_NO_DIM; do
+    out="$(printf '%s' "$payload" | HOME="$test_home" \
+      env "$mode=1" bash config/copilot/statusline.sh)"
+    if printf '%s' "$out" | grep -q $'\033\['; then
+      echo "$mode=1 still emits ANSI escapes" >&2
+      return 1
+    fi
+    printf '%s' "$out" | grep -Fq 'Sonnet 4.5'
+  done
+  out="$(printf '%s' "$payload" | HOME="$test_root/blocked-home" bash config/copilot/statusline.sh)"
+  if printf '%s' "$out" | grep -q $'\033\['; then
+    echo "a missing color include still emits ANSI escapes" >&2
+    return 1
+  fi
+
+  # An older include without C_FG_BRIGHT falls back to C_FG, never to empty.
+  old_home="$test_root/old-include-home"
+  mkdir -p "$old_home/.local/share/dot-configs/apollo/current/generated"
+  grep -v 'C_FG_BRIGHT=' "$colors_file" \
+    >"$old_home/.local/share/dot-configs/apollo/current/generated/statusline-colors.sh"
+  out="$(printf '%s' "$payload" | HOME="$old_home" \
+    COPILOT_STATUSLINE_NO_ICONS=1 COPILOT_STATUSLINE_SEGMENTS='model' \
+    bash config/copilot/statusline.sh)"
+  printf '%s' "$out" | grep -Fq $'\033[38;2;0;0;9mModel\033[0m \033[38;2;0;0;5mSonnet 4.5\033[0m' || {
+    echo "an older color include did not fall back to C_FG" >&2
+    return 1
+  }
+
+  # The shared generator must not change Claude's status line.
+  if grep -Fq 'C_FG_BRIGHT' config/claude/statusline.sh; then
+    echo "Claude status line must not adopt the bright foreground role" >&2
+    return 1
+  fi
+  out="$(printf '{}' | HOME="$test_home" bash config/claude/statusline.sh)"
+  if printf '%s' "$out" | grep -Fq $'\033[38;2;0;0;8m'; then
+    echo "Claude status line started emitting the bright foreground color" >&2
+    return 1
+  fi
+
   rm -rf "$test_root"
   test_root=""
   trap - RETURN
@@ -1382,6 +1828,7 @@ run_smoke() {
   run_subagent_smoke
   run_claude_subagent_limit_smoke
   run_model_default_smoke
+  run_claude_github_mcp_warning_smoke
   run_copilot_terminal_smoke
   run_global_instructions_smoke
   run_wiki_smoke
@@ -1397,12 +1844,14 @@ case "${1:-all}" in
   apollo) run_apollo_smoke ;;
   apollo-online) DOT_CONFIGS_INSTALL_LIB_ONLY=1 source install.sh; verify_apollo_release_pins ;;
   instructions) run_global_instructions_smoke ;;
+  models) run_model_default_smoke ;;
+  mcp) run_claude_github_mcp_warning_smoke ;;
   wiki) run_wiki_smoke; run_pipeline_scripts_smoke; run_rmux_keymap_docs_smoke ;;
   rmux) run_rmux_helpers_smoke; run_rmux_keymap_docs_smoke; run_retired_config_migration_smoke; run_rmux_smoke ;;
   shellcheck) run_shellcheck ;;
   all) run_smoke; run_shellcheck ;;
   *)
-    echo "usage: $0 [smoke|apollo|apollo-online|instructions|wiki|rmux|shellcheck|all]" >&2
+    echo "usage: $0 [smoke|apollo|apollo-online|instructions|models|mcp|wiki|rmux|shellcheck|all]" >&2
     exit 2
     ;;
 esac

--- a/wiki/Apollo-Theme-zh-CN.md
+++ b/wiki/Apollo-Theme-zh-CN.md
@@ -58,6 +58,10 @@ Bundle hash 包含 release lock 和 adapter code。安装器会先验证每个�
 
 生成的运行文件是本机状态。不要提交它们。
 
+### 状态栏颜色角色
+
+共享 include 从规范 `foregroundBright` 颜色生成 `C_FG_BRIGHT`。Copilot 用它显示 Model、Effort、Path 和 Branch 的值。旧 bundle 回退到普通前景色；无色模式仍输出纯文本。Claude 保持原有颜色。
+
 ## 更新
 
 更新 Apollo：

--- a/wiki/Apollo-Theme.md
+++ b/wiki/Apollo-Theme.md
@@ -58,6 +58,10 @@ Installed consumers link to `current`:
 
 Generated runtime files are local state. Do not commit them.
 
+### Status-line color roles
+
+The shared include generates `C_FG_BRIGHT` from the canonical `foregroundBright` color. Copilot uses it for Model, Effort, Path, and Branch values. Older bundles fall back to the normal foreground; no-color mode remains plain text. Claude keeps its existing colors.
+
 ## Updates
 
 To update Apollo:

--- a/wiki/Claude-Code-zh-CN.md
+++ b/wiki/Claude-Code-zh-CN.md
@@ -27,23 +27,25 @@ Claude Code 第一次启动时会问是否允许自定义 `dummy` API key。请�
 受管默认值：
 
 ```text
-Claude 端名称： gpt-6-astra[1m]
-Picker 名称：    GPT-6 Astra
+Claude 端名称： claude-sonnet-5[1m]
+Picker 名称：    原生 Sonnet 名称
 客户端 effort：  max
 Relay 路由：     gptModel
 上游模型：       gpt-6-astra
 ```
 
-名称中没有 `opus`，所以 copilot-relay 会把它发送到 `gptModel`。
+Claude Code 保留原生客户端身份。名称中没有 `opus`，所以 copilot-relay 会把它发送到 `gptModel`。
 
 其他路由：
 
 | Claude 端名称 | Relay lane | 上游 |
 |---|---|---|
 | `claude-opus-5[1m]` | `opusModel` | `claude-opus-5` |
-| Haiku / small-fast aliases | `gptModel` | `gpt-6-astra` |
+| `claude-haiku-4-5-20251001`（Haiku / small-fast） | `gptModel` | `gpt-6-astra` |
 
-`[1m]` 后缀让 Claude Code 使用一百万 token 的模型 context 计数；relay 向上游发送规范 ID `gpt-6-astra`。自动压缩刻意在 75,000 tokens 时触发，远早于 Astra 的 1M 总窗口内公布的 872,000-token prompt 上限。这并不意味着会保留完整的 1M-token 对话历史。Relay 端 thinking 在 `config/copilot-relay/config.yaml` 中设为 `max`。
+客户端名称和上游模型是两层。客户端保留原生 Anthropic ID；上游模型由 relay 决定。不要把 GPT ID 或 `_NAME` / `_DESCRIPTION` 显示覆盖写进 Claude 端设置。
+
+`[1m]` 后缀让 Claude Code 使用一百万 token 的模型 context 计数；relay 向上游发送规范 ID `gpt-6-astra`。Haiku ID 是已安装 CLI 自身的 small-fast ID，不加 `[1m]` 后缀。自动压缩刻意在 75,000 tokens 时触发，远早于 Astra 的 1M 总窗口内公布的 872,000-token prompt 上限。这并不意味着会保留完整的 1M-token 对话历史。Relay 端 thinking 在 `config/copilot-relay/config.yaml` 中设为 `max`。
 
 使用本设置前，请先使用支持 GPT-6 Astra 的 relay 构建（见 [copilot-relay issue #57](https://github.com/D0n9X1n/copilot-relay/issues/57)）。修改模型时应同时更新 `config/claude/settings.json`、`config/zsh/claude.zsh` 和 `config/zsh/cc.zsh`；wrapper 的 `--model` 优先于设置文件。Relay 的 `gptModel` 不带后缀，空白的 `webSearchBackend` 也使用 Astra。Opus 路由保持独立。
 
@@ -59,7 +61,11 @@ Sonnet-facing 槽位通过 `gptModel` 路由到 GPT-6 Astra；Opus 仍使用独�
 |---|---|
 | `ANTHROPIC_BASE_URL` | `http://127.0.0.1:4142` |
 | `ANTHROPIC_AUTH_TOKEN` | 本机占位符 `dummy` |
-| `ANTHROPIC_MODEL` | `gpt-6-astra[1m]` |
+| `ANTHROPIC_MODEL` | `claude-sonnet-5[1m]` |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL` | `claude-sonnet-5[1m]` |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL` | `claude-haiku-4-5-20251001` |
+| `ANTHROPIC_SMALL_FAST_MODEL` | `claude-haiku-4-5-20251001` |
+| `model` | `sonnet`；选择器自身的短别名 |
 | `MODEL_REASONING_EFFORT` | `max`；启动器同时传入 `--effort max` |
 | `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` | `16` |
 | `statusLine.refreshInterval` | `100` |
@@ -90,15 +96,19 @@ Claude Code 2.1.261 要求 `autoCompactWindow` 至少为 100,000，因此不能�
 
 `config/claude/CLAUDE.md` 安装为 `~/.claude/CLAUDE.md`，并设置用户级回复风格。对话文字默认直接、简短。明确要求更多细节时仍按要求回答；代码、命令、检查结果、证据、必要说明、安全信息和技术准确性必须保持完整。
 
+全局文件只保留可复用行为，加一条条件指针：这些设置从 `~/Public/dot-configs` 同步；要修改它们，先读该目录的 `.claude/CLAUDE.md`。仓库专属规则——Wiki 是完整信息源、manifest、检查、双语页面——留在本仓库自己的 `.claude/CLAUDE.md`，这样无关项目不会加载它们。
+
 ## 启动器
 
 `config/zsh/claude.zsh` 包装 `claude` 并添加：
 
 ```text
 --permission-mode bypassPermissions
---model gpt-6-astra[1m]
+--model claude-sonnet-5[1m]
 --effort max
 ```
+
+命令行上显式给出 `--model`、`--model=` 或 `--effort` 时，对应的默认值不再注入；另一个默认值仍然生效。
 
 二进制会拒绝 settings 中的 `permissions.defaultMode: bypassPermissions`。命令行 flag 可以工作。Claude Code 可能在运行时重写 settings，所以 wrapper 也固定模型和 effort。
 
@@ -156,7 +166,7 @@ WakaTime marketplace 指向官方 `wakatime/claude-code-wakatime` Git 仓库。
 
 ### 小任务出现 `model_not_supported`
 
-保持 Haiku 和 small-fast aliases 都是 `gpt-6-astra[1m]`。同时检查 relay base URL。
+保持 Haiku 和 small-fast aliases 都是 `claude-haiku-4-5-20251001`，即已安装 CLI 自身的 small-fast ID。那里不要加 `[1m]` 后缀。同时检查 relay base URL。
 
 ### Relay 重写 settings
 

--- a/wiki/Claude-Code.md
+++ b/wiki/Claude-Code.md
@@ -27,23 +27,25 @@ The first Claude Code launch asks if the custom `dummy` API key is allowed. Choo
 The tracked default is:
 
 ```text
-Claude-facing name: gpt-6-astra[1m]
-Picker name:        GPT-6 Astra
+Claude-facing name: claude-sonnet-5[1m]
+Picker name:        native Sonnet name
 Client effort:      max
 Relay route:        gptModel
 Upstream model:     gpt-6-astra
 ```
 
-The name has no `opus`, so copilot-relay sends it to `gptModel`.
+Claude Code keeps its native client identity. The name has no `opus`, so copilot-relay sends it to `gptModel`.
 
 Other routes:
 
 | Claude-facing name | Relay lane | Upstream |
 |---|---|---|
 | `claude-opus-5[1m]` | `opusModel` | `claude-opus-5` |
-| Haiku / small-fast aliases | `gptModel` | `gpt-6-astra` |
+| `claude-haiku-4-5-20251001` (Haiku / small-fast) | `gptModel` | `gpt-6-astra` |
 
-The `[1m]` suffix keeps Claude Code's one-million-token model context accounting; the relay sends canonical `gpt-6-astra` upstream. Automatic compaction deliberately starts at 75,000 tokens, well before Astra's advertised 872,000-token prompt limit within its 1M total window. This does not retain a full 1M-token conversation history. Relay-side thinking is `max` in `config/copilot-relay/config.yaml`.
+Client names and upstream models are separate layers. The client keeps native Anthropic ids; the relay decides the upstream model. Do not write a GPT id, or a `_NAME` / `_DESCRIPTION` display override, into Claude-facing settings.
+
+The `[1m]` suffix keeps Claude Code's one-million-token model context accounting; the relay sends canonical `gpt-6-astra` upstream. The Haiku id is the installed CLI's own small-fast id and takes no `[1m]` suffix. Automatic compaction deliberately starts at 75,000 tokens, well before Astra's advertised 872,000-token prompt limit within its 1M total window. This does not retain a full 1M-token conversation history. Relay-side thinking is `max` in `config/copilot-relay/config.yaml`.
 
 Use a relay build with GPT-6 Astra support before relying on this setup (tracked in [copilot-relay issue #57](https://github.com/D0n9X1n/copilot-relay/issues/57)). Update the model in `config/claude/settings.json`, `config/zsh/claude.zsh`, and `config/zsh/cc.zsh` together; the wrappers' `--model` overrides the settings. The relay's `gptModel` stays suffix-free. Its blank `webSearchBackend` also uses Astra. Keep the Opus route separate.
 
@@ -59,7 +61,11 @@ The Sonnet-facing slot routes to GPT-6 Astra through `gptModel`; Opus stays on i
 |---|---|
 | `ANTHROPIC_BASE_URL` | `http://127.0.0.1:4142` |
 | `ANTHROPIC_AUTH_TOKEN` | local placeholder `dummy` |
-| `ANTHROPIC_MODEL` | `gpt-6-astra[1m]` |
+| `ANTHROPIC_MODEL` | `claude-sonnet-5[1m]` |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL` | `claude-sonnet-5[1m]` |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL` | `claude-haiku-4-5-20251001` |
+| `ANTHROPIC_SMALL_FAST_MODEL` | `claude-haiku-4-5-20251001` |
+| `model` | `sonnet`; the picker's own short alias |
 | `MODEL_REASONING_EFFORT` | `max`; launch wrappers also pass `--effort max` |
 | `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` | `16` |
 | `statusLine.refreshInterval` | `100` |
@@ -90,15 +96,19 @@ Do not put the local state file in Git.
 
 `config/claude/CLAUDE.md` installs as `~/.claude/CLAUDE.md` and sets user-wide response style. Conversational prose is direct and concise by default. Requests for more detail still win, and code, commands, findings, evidence, caveats, safety information, and technical precision stay complete.
 
+The global file holds only reusable behavior plus one conditional pointer: these settings are synced from `~/Public/dot-configs`, and a change to them starts by reading that folder's `.claude/CLAUDE.md`. Repo-only rules — the Wiki source of truth, the manifest, checks, bilingual pages — stay in this repo's own `.claude/CLAUDE.md`, so an unrelated project never loads them.
+
 ## Launch wrappers
 
 `config/zsh/claude.zsh` wraps `claude` and adds:
 
 ```text
 --permission-mode bypassPermissions
---model gpt-6-astra[1m]
+--model claude-sonnet-5[1m]
 --effort max
 ```
+
+An explicit `--model`, `--model=`, or `--effort` on the command line suppresses the matching default; the other default still applies.
 
 The binary rejects `permissions.defaultMode: bypassPermissions` in settings. The command-line flag works. The wrapper also pins model and effort because Claude Code can rewrite settings at runtime.
 
@@ -156,7 +166,7 @@ The first prompt was answered no. In local `~/.claude.json`, move `dummy` from `
 
 ### Small jobs get `model_not_supported`
 
-Keep both Haiku and small-fast aliases set to `gpt-6-astra[1m]`. Also check the relay base URL.
+Keep both the Haiku and small-fast aliases set to `claude-haiku-4-5-20251001`, the installed CLI's own small-fast id. Do not add a `[1m]` suffix there. Also check the relay base URL.
 
 ### Relay rewrites settings
 

--- a/wiki/Copilot-CLI-zh-CN.md
+++ b/wiki/Copilot-CLI-zh-CN.md
@@ -32,11 +32,13 @@ Copilot 安装两个指令文件：
 - `config/copilot/copilot-instructions.md` → `~/.copilot/copilot-instructions.md`
 - `config/copilot/AGENTS.md` → `~/.copilot/AGENTS.md`
 
-原生文件保存 Copilot 的用户级行为。它让对话文字默认直接、简短。明确要求更多细节时仍按要求回答；代码、命令、检查结果、证据、必要说明、安全信息和技术准确性必须保持完整。
+原生文件保存 Copilot 的用户级行为。它让对话文字默认直接、简短。明确要求更多细节时仍按要求回答；代码、命令、检查结果、证据、必要说明、安全信息和技术准确性必须保持完整。它也保留工作规则：直接运行工具和命令，不再询问；直接开始任务。
 
-`AGENTS.md` 只保留 Wiki 指针，用于可复用的 GitHub Wiki 和 release 工作。
+两个全局文件只保留可复用行为，加一条条件指针：这些设置从 `~/Public/dot-configs` 同步；要修改它们，先读该目录的 `.github/copilot-instructions.md`。仓库专属规则留在本仓库自己的 `.github/copilot-instructions.md`，这样无关项目不会加载它们。
 
-`config/zsh/custom.zsh` 把 `~/.copilot` 加入 `COPILOT_CUSTOM_INSTRUCTIONS_DIRS`。它会保留已有路径，也不会重复添加。
+Copilot 不一定会内联全局 `AGENTS.md`，所以原生文件用绝对路径写明 `~/.copilot/AGENTS.md`，并自己重复一次设置来源指针。任何一个文件单独加载时，都能说明全局设置在哪里。
+
+`config/zsh/custom.zsh` 把 `~/.copilot` 加入 `COPILOT_CUSTOM_INSTRUCTIONS_DIRS`。它会保留已有路径，也不会重复添加。该接线属于 shell 层，由 `scripts/check.sh instructions` 断言，不再写进指令正文。
 
 ## 终端身份
 
@@ -74,6 +76,8 @@ Copilot 状态栏与 Claude 共享五行布局和本机生成的 Apollo 颜色�
 5. repo、branch、diff、stash、worktree
 
 它用一次 `jq` 读取 session JSON。两个 provider 状态脚本读取同一个本机生成 Apollo 颜色 include；文件缺失时会回退为可读的无色输出。Git 数据按工作目录缓存五秒。GitHub auth 数据缓存五分钟。
+
+Copilot 从该共享 include 中多用一个颜色角色。Model、Effort、Path 和 Branch 的值使用亮前景角色，让会话身份从普通值中突出。它们的标签保留强调色：Model 为黄色，Path 为青色，Run 为紫色。普通分隔符和 context 容量后缀改用暗前景角色，而不是纯 dim 属性。实时 subagent 行及其分隔线保持不变。Claude 状态栏不使用亮前景角色，所以共享生成器不会改变它。
 
 有用的环境变量：
 

--- a/wiki/Copilot-CLI.md
+++ b/wiki/Copilot-CLI.md
@@ -32,11 +32,13 @@ Copilot has two installed instruction files:
 - `config/copilot/copilot-instructions.md` → `~/.copilot/copilot-instructions.md`
 - `config/copilot/AGENTS.md` → `~/.copilot/AGENTS.md`
 
-The native file keeps Copilot's user-wide behavior. It makes conversational prose direct and concise by default. Requests for more detail still win, and code, commands, findings, evidence, caveats, safety information, and technical precision stay complete.
+The native file keeps Copilot's user-wide behavior. It makes conversational prose direct and concise by default. Requests for more detail still win, and code, commands, findings, evidence, caveats, safety information, and technical precision stay complete. It also keeps the working rules: run tools and commands without asking, and work on the task directly.
 
-`AGENTS.md` stays focused on the Wiki pointer for reusable GitHub Wiki and release work.
+Both global files hold only reusable behavior plus one conditional pointer: these settings are synced from `~/Public/dot-configs`, and a change to them starts by reading that folder's `.github/copilot-instructions.md`. Repo-only rules stay in this repo's own `.github/copilot-instructions.md`, so an unrelated project never loads them.
 
-`config/zsh/custom.zsh` adds `~/.copilot` to `COPILOT_CUSTOM_INSTRUCTIONS_DIRS`. It keeps any paths that already exist and does not add a duplicate.
+Copilot does not reliably inline the global `AGENTS.md`, so the native file names `~/.copilot/AGENTS.md` by absolute path and repeats the settings-source pointer itself. Either file alone still says where the global settings live.
+
+`config/zsh/custom.zsh` adds `~/.copilot` to `COPILOT_CUSTOM_INSTRUCTIONS_DIRS`. It keeps any paths that already exist and does not add a duplicate. That wiring is a shell concern and is asserted by `scripts/check.sh instructions`, not repeated in the instruction text.
 
 ## Terminal identity
 
@@ -74,6 +76,8 @@ The Copilot status line shares the five-line layout and locally generated Apollo
 5. repo, branch, diff, stash, worktree
 
 It reads session JSON with one `jq` call. Both provider status scripts source the same generated Apollo color include and fall back to readable uncolored output when it is absent. Git data is cached for five seconds per working directory. GitHub auth data is cached for five minutes.
+
+Copilot uses one extra color role from that shared include. Model, Effort, Path, and Branch print their values in the bright foreground role, so the identity of the session stands out from ordinary values. Their labels keep accent roles: Model is yellow, Path is aqua, Run is purple. Ordinary segment separators and the context capacity suffix use the dim foreground role rather than the plain dim attribute. The live-subagent rows and their separator are unchanged. Claude's status line does not use the bright role, so the shared generator does not change it.
 
 Useful environment switches:
 

--- a/wiki/Development-and-Releases-zh-CN.md
+++ b/wiki/Development-and-Releases-zh-CN.md
@@ -65,9 +65,15 @@ scripts/check.sh apollo
 scripts/check.sh apollo-online
 scripts/check.sh shellcheck
 scripts/check.sh instructions
+scripts/check.sh models
+scripts/check.sh mcp
 scripts/check.sh wiki
 scripts/check.sh rmux
 ```
+
+`models` 断言受管模型选择器：Claude 设置和启动器 wrapper 中的原生客户端 ID、Copilot 自己的 GPT-6 Astra 设置，以及 relay 独立的 Opus 路由。`mcp` 覆盖安装器只读的 GitHub MCP 覆盖警告。
+
+状态栏布局、缓存和生成的 palette 由两个 provider 共享，所以修改任一脚本或生成器时，由 `apollo` 和 `smoke` 一起检查。provider 各自的强调仍然不同：Copilot 使用亮前景角色并保留实时 subagent 行，Claude 两者都不用。修改共享生成器时，保持 Claude 输出不变。
 
 CI 使用同一个脚本：
 

--- a/wiki/Development-and-Releases.md
+++ b/wiki/Development-and-Releases.md
@@ -65,9 +65,15 @@ scripts/check.sh apollo
 scripts/check.sh apollo-online
 scripts/check.sh shellcheck
 scripts/check.sh instructions
+scripts/check.sh models
+scripts/check.sh mcp
 scripts/check.sh wiki
 scripts/check.sh rmux
 ```
+
+`models` asserts the tracked model selectors: native client ids in Claude settings and launcher wrappers, Copilot's own GPT-6 Astra settings, and the relay's separate Opus route. `mcp` covers the installer's read-only GitHub MCP override warning.
+
+The status-line layout, cache, and generated palette are shared by both providers, so a change to either script or to the generator is checked by `apollo` and `smoke` together. Provider-specific emphasis still differs: Copilot uses the bright foreground role and keeps the live-subagent rows, Claude does neither. Keep Claude's output unchanged when editing the shared generator.
 
 CI uses the same script:
 

--- a/wiki/RMUX-zh-CN.md
+++ b/wiki/RMUX-zh-CN.md
@@ -130,7 +130,7 @@ set -s set-clipboard on
 
 ```sh
 rmux claude --permission-mode bypassPermissions \
-  --model 'gpt-6-astra[1m]' --effort max
+  --model 'claude-sonnet-5[1m]' --effort max
 ```
 
 `rmux claude` 会启用 Claude Code 的 tmux teammate mode，并在 Claude 进程的 `PATH` 前加入私有、进程级的 `tmux` shim，使 teammate 命令指向 RMUX。它不会替换系统全局的 `tmux`。本仓库不会运行 `rmux setup tmux-shim`。

--- a/wiki/RMUX.md
+++ b/wiki/RMUX.md
@@ -130,7 +130,7 @@ Use normal `claude` or the repository's `cc` helper for an ordinary Claude Code 
 
 ```sh
 rmux claude --permission-mode bypassPermissions \
-  --model 'gpt-6-astra[1m]' --effort max
+  --model 'claude-sonnet-5[1m]' --effort max
 ```
 
 `rmux claude` enables Claude Code's tmux teammate mode and prepends a private, process-scoped `tmux` shim so Claude's teammate commands target RMUX. It does not replace the global `tmux` executable. This repository deliberately does not run `rmux setup tmux-shim`.

--- a/wiki/Repository-Operations-zh-CN.md
+++ b/wiki/Repository-Operations-zh-CN.md
@@ -127,6 +127,20 @@ Token 和 API key 只能放在本机 Copilot MCP 文件中。不要把它们加�
 
 托管 GitHub MCP 使用 Bearer PAT header。它的 OAuth dynamic client registration 不适用于当前设置。
 
+### 本机 GitHub MCP 覆盖
+
+Claude 的 local scope 条目位于 `~/.claude.json` 的 `projects[].mcpServers` 下。它们完整覆盖同名用户级条目，不会合并 header。MCP 导入会保留这些本机条目。
+
+导入后，如果本机 GitHub HTTP 条目缺少认证 header，而用户级条目为同一托管 endpoint 配置了 Bearer token，`install.sh` 会发出警告。拥有独立认证、OAuth、`headersHelper` 或不同 endpoint 的条目会跳过。检查只打印转义后的项目路径，绝不打印凭据；它不修改状态，也不验证 token 是否有效。
+
+先检查覆盖是否有意设置。若不是，请在受影响项目中运行以下命令，然后重新连接或重启 Claude Code：
+
+```sh
+claude mcp remove github --scope local
+```
+
+这只移除本机重复条目，让 Claude 使用用户级凭据。安装器不会替你移除覆盖。
+
 ## 本机状态
 
 这些路径是本机状态，不是配置源：
@@ -139,6 +153,8 @@ Token 和 API key 只能放在本机 Copilot MCP 文件中。不要把它们加�
 - `~/.sonicterm/logs/` — SonicTerm 日志
 - SonicTerm save lock 和备份
 - `~/.tmux/plugins/` 和旧 resurrect 文件
+
+本机状态和用户全局文件不是一回事。`~/.claude/CLAUDE.md`、`~/.copilot/AGENTS.md` 和 `~/.copilot/copilot-instructions.md` 是用户全局文件：它们链接到 `config/` 中的受管源文件，在本仓库修改后重新安装。`~/.claude.json` 是工具自己拥有的本机状态。MCP 导入只替换其顶层 `mcpServers` 字段，不修改按项目设置的覆盖。安装器的其他步骤可能更新本机偏好，例如选中的 Apollo 主题。
 
 ## 已停用链接
 

--- a/wiki/Repository-Operations.md
+++ b/wiki/Repository-Operations.md
@@ -127,6 +127,20 @@ Put tokens and API keys only in the local Copilot MCP file. Do not add them to t
 
 The hosted GitHub MCP uses a Bearer PAT header. Its OAuth dynamic client registration does not work with this setup.
 
+### Local GitHub MCP overrides
+
+Claude's local-scope entries live under `projects[].mcpServers` in `~/.claude.json`. They override same-name user entries completely; headers are not merged. The MCP import leaves these local entries untouched.
+
+After import, `install.sh` warns if a local GitHub HTTP entry has no auth header while the user entry has a configured Bearer token for the same hosted endpoint. It skips entries with their own auth, OAuth, `headersHelper`, or a different endpoint. The check prints escaped project paths only, never credentials; it does not change state or test token validity.
+
+Review the override first. If it is unintended, run this inside the affected project, then reconnect or restart Claude Code:
+
+```sh
+claude mcp remove github --scope local
+```
+
+This removes only the local duplicate so Claude can use the user-scoped credentials. The installer never removes overrides for you.
+
 ## Local state
 
 These paths are local and are not config sources:
@@ -139,6 +153,8 @@ These paths are local and are not config sources:
 - `~/.sonicterm/logs/` — SonicTerm logs
 - SonicTerm save locks and backups
 - `~/.tmux/plugins/` and old resurrect files
+
+Local state is not the same as a user global. `~/.claude/CLAUDE.md`, `~/.copilot/AGENTS.md`, and `~/.copilot/copilot-instructions.md` are user globals: links to tracked sources in `config/`, edited here and reinstalled. `~/.claude.json` is local state the tools own. The MCP import replaces only its top-level `mcpServers` field and leaves per-project overrides alone. Other installer steps can update local preferences, such as the selected Apollo theme.
 
 ## Retired links
 

--- a/wiki/Services-and-Automation-zh-CN.md
+++ b/wiki/Services-and-Automation-zh-CN.md
@@ -4,6 +4,8 @@
 
 `install.sh` 会设置工具、本机服务、共享 MCP 数据、WakaTime 和清理任务。
 
+导入 MCP servers 之后，安装器会对以下情况发出警告：某个项目用未认证的同 endpoint 副本覆盖了 github server。该检查是只读的，不打印任何 auth 值。检测的具体形态和按 scope 的修复方式见[仓库操作](Repository-Operations-zh-CN.md)。
+
 ## 新 Mac 设置
 
 在 macOS 上，安装器可以添加：

--- a/wiki/Services-and-Automation.md
+++ b/wiki/Services-and-Automation.md
@@ -4,6 +4,8 @@ English | [简体中文](Services-and-Automation-zh-CN.md)
 
 `install.sh` sets up tools, local services, shared MCP data, WakaTime, and cleanup jobs.
 
+After importing MCP servers, the installer warns about any project that overrides the github server with an unauthenticated copy of the same endpoint. The check is read-only and prints no auth values. See [Repository operations](Repository-Operations.md) for the shape it detects and the scoped fix.
+
 ## New Mac setup
 
 On macOS, the installer can add:


### PR DESCRIPTION
## Summary
- Keep global Claude/Copilot instructions reusable with a conditional managed-source pointer; move repo-only rules into native project instruction files.
- Restore native Sonnet/Haiku client identities and document the policy in project CLAUDE.md, preserving GPT-6 Astra relay routing and the separate Opus route.
- Brighten Copilot's Apollo footer without changing content, layout, metrics, caches, thresholds, or subagent rows; warn without modifying headerless local GitHub MCP overrides.

Closes #24
Closes #25
Closes #26
Closes #27

## Test plan
- [x] `scripts/check.sh mcp` and `scripts/check.sh all` pass, including Bash 3.2, ShellCheck, Apollo, instructions, models, Wiki, and RMUX checks.
- [x] Injected a silent mutation into an authenticated local-MCP fixture: the check now exits 1 instead of accepting a failed byte-preservation check.
- [x] Actual installed Claude wrapper resolves native Sonnet; compaction reports `threshold: 75000`, `enforced: true`, `effective_window: 100000`, with no output-budget override.
- [x] Native Sonnet and Haiku requests both reach relay 0.3.5 and map to GPT-6 Astra with HTTP 200.
- [x] Actual Claude/Copilot CLI probes load global style everywhere, repository rules only in the managed repo, and the managed-settings source pointer.
- [x] Five before/after footer states have identical ANSI-stripped text; real Copilot TUI executes the five-row colored footer, and narrow/wide rendered output was visually inspected.
- [x] Two installer passes verify 24 links, three launchd templates, generated bright colors, idempotence, and healthy relay; local MCP overrides, GitHub credentials, and tracked source bytes remain unchanged.
- [x] Unrelated Claude settings preserved; relay config, Copilot settings, Claude footer, and `gg` remain byte-identical to the baseline. GitHub MCP remains connected at user scope after installation.
- [x] GitHub CI passed: macOS smoke tests and Ubuntu ShellCheck.

## Review
Independent Sonnet review of the Opus implementation found a test failure-propagation gap, which was reproduced and fixed. Independent Opus review of the Sonnet follow-up changes passed and closed that finding.

Cost: 8 dispatches, ~80 min wall-clock, models: Sonnet, Opus.

Generated with [Claude Code](https://claude.com/claude-code).
