### PR TITLE
Require safe cleanup after PR merges

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -57,3 +57,4 @@ For a config change, run `./install.sh` twice after checks pass. Then verify the
 This repo is public. Do not commit tokens, keys, auth files, logs, runtime state, SonicTerm save locks, or `.claude/worktrees/`.
 
 Do not force-push. Do not use `--no-verify` unless the user asks.
+After merging a PR, complete the branch/worktree cleanup in `wiki/Development-and-Releases.md`, preserving active and unmerged work.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -53,3 +53,4 @@ For config changes, run `./install.sh` twice after checks pass.
 This repo is public. Do not commit tokens, keys, auth files, logs, runtime state, SonicTerm save locks, or `.claude/worktrees/`.
 
 Do not force-push. Do not use `--no-verify` unless the user asks.
+After merging a PR, complete the branch/worktree cleanup in `wiki/Development-and-Releases.md`, preserving active and unmerged work.

--- a/wiki/Development-and-Releases-zh-CN.md
+++ b/wiki/Development-and-Releases-zh-CN.md
@@ -138,6 +138,40 @@ Release 前：
 2. 检查它们属于 release milestone。
 3. 工作完成后关闭 milestone。
 
+## 合并后必须清理
+
+PR 合并后，只有清理了不再活跃的功能分支和临时 worktree，或明确报告了保留的例外，
+才算完成。
+
+1. 确认 PR 已合并，并获取最新的基础分支。检查 `git status --short`、
+   `git worktree list --porcelain` 和分支祖先关系；分支的名称或年龄不能证明工作已合并。
+2. 检查 worktree 和锁由哪个会话持有。不要删除活跃 worktree，也不要为了让清理通过
+   就解除其他会话的锁。
+3. 只在自己拥有的 checkout 中切离已合并的功能分支。先用普通的
+   `git worktree remove` 删除干净、非活跃的 worktree，再用 `git branch -d`
+   删除本地分支；不要强制移除。
+4. 如果已确认合并的远端分支仍存在，删除它，再运行 `git fetch --prune origin`。
+   保留 `main` 和真正活跃的分支。
+5. 报告最终工作区状态、剩余分支/worktree 和保留的例外。只清理可再生成的构建产物，
+   不要删除凭据、运行状态或其他会话的文件。
+
+未提交改动或独有提交会阻止普通删除。应原地保留，或在明确约定的陈旧工作清理之前，
+创建并验证私有恢复归档。不要用强制删除绕过这些检查。
+
+`git branch -d` 依据祖先关系，可能拒绝删除经 squash/rebase 合并的分支。仅在这种情况下，
+确认以下全部条件后，才允许使用 `git branch -D`：
+
+- PR 已合并，且合并结果可从当前基础分支到达。
+- 本地分支 tip 与 PR 合并时记录的 head commit 完全一致，而不是与生成的 squash/rebase
+  commit 比较。如果本地有额外或重写的提交，即使原 PR diff 已进入目标分支，也必须保留。
+- 该 PR head 的全部改动均已合并。`git cherry -v main <branch>` 没有 `+` 条目可以确认
+  逐提交补丁等价；多个提交合并成一个 squash commit 后仍可能显示 `+`，这时应比较
+  完整 PR diff 与对应的 squash commit。
+
+删除前立即重新检查每个分支 tip，包括远端 tip；如果它已变化，或无法验证 PR 合并时的
+head 或补丁等价，就保留分支。不要仅凭 PR 已关闭就判断安全，也不要借此强制删除脏的或
+活跃的 worktree。
+
 ## 版本
 
 Tag 使用 `vX.Y.Z`：

--- a/wiki/Development-and-Releases.md
+++ b/wiki/Development-and-Releases.md
@@ -138,6 +138,45 @@ Before a release:
 2. Check that they belong to the release milestone.
 3. Close the milestone when the work is complete.
 
+## Required post-merge cleanup
+
+A merged PR is not complete until its inactive feature branches and temporary
+worktrees are cleaned up, or preserved exceptions are explicitly reported.
+
+1. Confirm the PR is merged and fetch the current base branch. Check
+   `git status --short`, `git worktree list --porcelain`, and branch ancestry;
+   a branch's age or name does not prove its work was merged.
+2. Check which sessions own the worktrees and locks. Never remove an active
+   worktree or clear another session's lock merely to make cleanup succeed.
+3. Switch away from the merged feature branch only in a checkout you own.
+   Remove clean, inactive worktrees before deleting their local branches with
+   `git branch -d`. Use ordinary `git worktree remove`, not forced removal.
+4. Delete the confirmed merged remote branch if it remains, then run
+   `git fetch --prune origin`. Keep `main` and genuinely active branches.
+5. Report the final working-tree status, remaining branches/worktrees, and any
+   preserved exceptions. Remove only disposable build outputs, never credentials,
+   runtime state, or another session's files.
+
+Uncommitted changes or unique commits block ordinary deletion. Preserve them in
+place, or create and verify a private recovery archive before an explicitly
+agreed stale-work cleanup. Do not use forced deletion to bypass these checks.
+
+`git branch -d` relies on ancestry and can refuse a squash/rebase-merged branch.
+For that case only, `git branch -D` is permitted after confirming all of these:
+
+- The PR is merged and its merge result is reachable from the current base.
+- The local branch tip exactly matches the PR's head commit recorded at merge,
+  not the resulting squash/rebase commit. Extra or rewritten local commits mean
+  preserve the branch, even when the original PR diff landed.
+- All changes from that recorded PR head landed. `git cherry -v main <branch>`
+  with no `+` entries confirms per-commit patch equivalence; a multi-commit squash
+  may still show `+`, so compare the complete PR diff with its squash commit.
+
+Recheck each branch tip immediately before deletion, including the remote tip;
+if it changed or the recorded PR head/equivalence cannot be verified, preserve it.
+Never infer safety from a PR being closed, or use this exception to force-remove
+a dirty or active worktree.
+
 ## Versions
 
 Tags use `vX.Y.Z`:


### PR DESCRIPTION
## Summary

- Make inactive local/remote branch and temporary-worktree cleanup part of PR completion.
- Add one-line pointers to the two repo-level instruction files and synchronized English/Chinese Development guidance.
- Protect active sessions, dirty files, unique commits, and changed branch tips; document a verified squash/rebase exception without an unattended destructive hook.

Closes #28

## Scope

Exactly four documentation files. No global instructions under config/, model settings, installer behavior, credentials, or runtime files change. This follows merged PR #29 rather than mixing into its #24–#27 implementation.

## Validation

- [x] `scripts/check.sh all` — exit 0, including instruction scope/line limits, Wiki graph/publish scripts, model defaults, Apollo, MCP warnings, RMUX, and ShellCheck.
- [x] `git diff --check`.
- [x] Verified the EN/ZH policy matches the reviewed and merged copilot-relay PR #62 policy exactly apart from heading level.
- [x] Cross-family review: PASS; repo instruction files remain at 60 and 56 lines.

## Cleanup already performed

The stopped implementation worktree and its 27 modified files were preserved in a verified private archive (bundle, binary patches, and full-file archive) plus a recovery stash before ordinary worktree removal. Its branch and PR #29's confirmed merged local/remote feature branches were deleted. No active work, global settings, credentials, or another session's browser outputs were removed.

## After merge

- [x] Wiki run 33988680882 succeeded on merge 1baf8e5; all 27 published pages match source and both Development pages were reached through their Home navigation.
- [x] Merged local/remote branch deleted, stale refs pruned; clean main and only the primary worktree verified.
- [x] Handed off clean main at 1baf8e54dcb27270da2e7301162a7b88950b7b3f for the separately owned v2.4.0 release; this PR does not tag or release.

Cost: 1 resumed cross-family review, elapsed time not separately measured, models: Sonnet 5, Opus 5.

Generated with [Claude Code](https://claude.com/claude-code)

